### PR TITLE
Removed temporary alert hiding on Orlando United page

### DIFF
--- a/dev/custom-pages/orlandounited.js
+++ b/dev/custom-pages/orlandounited.js
@@ -1,7 +1,4 @@
 (function() {
-  // Hiding alerts temporarily to avoid duplicate information
-  $('.status-alert').parent().hide();
-
   // Make Flickr behave
   function responsiveFlickrEmbeds() {
     $('.flickr-embed-frame').each(function() {


### PR DESCRIPTION
Removes temporary alert hiding, which, after updating alert styles in v2.1.0, was causing the entire body to be hidden