### PR TITLE
Header content updates

### DIFF
--- a/dev/acf-fields.json
+++ b/dev/acf-fields.json
@@ -892,13 +892,45 @@
                 "endpoint": 0
             },
             {
+                "key": "field_59aed971c187c",
+                "label": "Header Content - Type of Content",
+                "name": "page_header_content_type",
+                "type": "radio",
+                "instructions": "Specify the type of content that should be displayed within the header.  Choose \"Title and subtitle\" to display a styled page title and optional subtitle, or choose \"Custom content\" to add any arbitrary content.  If \"Custom content\" is selected, a page title and subtitle are NOT included by default and should be added manually.",
+                "required": 1,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "choices": {
+                    "title_subtitle": "Title and subtitle",
+                    "custom": "Custom content"
+                },
+                "allow_null": 0,
+                "other_choice": 0,
+                "save_other_choice": 0,
+                "default_value": "title_subtitle",
+                "layout": "vertical",
+                "return_format": "value"
+            },
+            {
                 "key": "field_58fe096728bcc",
                 "label": "Header Title Text",
                 "name": "page_header_title",
                 "type": "text",
                 "instructions": "Overrides the page title.",
                 "required": 0,
-                "conditional_logic": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_59aed971c187c",
+                            "operator": "==",
+                            "value": "title_subtitle"
+                        }
+                    ]
+                ],
                 "wrapper": {
                     "width": "",
                     "class": "",
@@ -908,9 +940,7 @@
                 "placeholder": "",
                 "prepend": "",
                 "append": "",
-                "maxlength": "",
-                "readonly": 0,
-                "disabled": 0
+                "maxlength": ""
             },
             {
                 "key": "field_58fe097f28bcd",
@@ -919,7 +949,15 @@
                 "type": "text",
                 "instructions": "",
                 "required": 0,
-                "conditional_logic": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_59aed971c187c",
+                            "operator": "==",
+                            "value": "title_subtitle"
+                        }
+                    ]
+                ],
                 "wrapper": {
                     "width": "",
                     "class": "",
@@ -929,9 +967,34 @@
                 "placeholder": "",
                 "prepend": "",
                 "append": "",
-                "maxlength": "",
-                "readonly": 0,
-                "disabled": 0
+                "maxlength": ""
+            },
+            {
+                "key": "field_59aed93dc187b",
+                "label": "Header Custom Contents",
+                "name": "page_header_content",
+                "type": "wysiwyg",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_59aed971c187c",
+                            "operator": "==",
+                            "value": "custom"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "tabs": "all",
+                "toolbar": "full",
+                "media_upload": 1,
+                "delay": 0
             },
             {
                 "key": "field_590ca453f6655",

--- a/functions.php
+++ b/functions.php
@@ -70,6 +70,14 @@ function get_media_background_picture_srcs( $attachment_xs_id, $attachment_sm_id
 			)
 		);
 
+		// Try to get a fallback -xs image if needed
+		if ( !$attachment_xs_id ) {
+			$bg_images = array_merge(
+				$bg_images,
+				array( 'xs' => get_attachment_src_by_size( $attachment_sm_id, $img_size_prefix ) )
+			);
+		}
+
 		// Remove duplicate image sizes, in case an old image isn't pre-cropped
 		$bg_images = array_unique( $bg_images );
 

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -215,11 +215,11 @@ function get_header_media_markup( $post, $videos, $images ) {
 		<div class="header-content">
 			<div class="header-content-flexfix">
 				<?php
-				if ( get_field( 'page_header_content_type', $post->ID ) === 'title_subtitle' ) {
-					echo get_header_content_title_subtitle( $post );
+				if ( get_field( 'page_header_content_type', $post->ID ) === 'custom' ) {
+					echo get_header_content_custom( $post );
 				}
 				else {
-					echo get_header_content_custom( $post );
+					echo get_header_content_title_subtitle( $post );
 				}
 				?>
 			</div>

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -96,9 +96,9 @@ function get_header_videos( $post ) {
 function get_nav_markup( $image=true ) {
 	ob_start();
 ?>
-	<nav class="navbar navbar-toggleable-md<?php echo $image ? ' navbar-inverse navbar-custom header-gradient' : ' navbar-light navbar-custom'; ?> py-4" role="navigation">
+	<nav class="navbar navbar-toggleable-md<?php echo $image ? ' navbar-inverse navbar-custom header-gradient' : ' navbar-light navbar-custom'; ?> py-2 py-sm-4" role="navigation">
 		<div class="container">
-			<button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#header-menu" aria-controls="header-menu" aria-expanded="false" aria-label="Toggle navigation">
+			<button class="navbar-toggler ml-auto" type="button" data-toggle="collapse" data-target="#header-menu" aria-controls="header-menu" aria-expanded="false" aria-label="Toggle navigation">
 				<span class="navbar-toggler-icon"></span>
 			</button>
 			<?php

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -76,10 +76,7 @@ function get_header_videos( $obj ) {
 	$field_id = get_object_field_id( $obj );
 	$title = '';
 
-	if ( is_404() ) {
-		$title = 'Page Not Found';
-	}
-	else if ( is_tax() || is_category() || is_tag() ) {
+	if ( is_tax() || is_category() || is_tag() ) {
 		$title = $obj->name;
 	}
 
@@ -142,6 +139,8 @@ function get_header_content_title_subtitle( $obj ) {
 	$subtitle = get_header_subtitle( $obj );
 
 	ob_start();
+
+	if ( $title ):
 ?>
 	<div class="header-content-inner d-flex h-75 align-items-center">
 		<div class="container">
@@ -157,6 +156,8 @@ function get_header_content_title_subtitle( $obj ) {
 		</div>
 	</div>
 <?php
+	endif;
+
 	return ob_get_clean();
 }
 
@@ -256,6 +257,7 @@ function get_header_media_markup( $obj, $videos, $images ) {
 ?>
 	<?php echo get_nav_markup(); ?>
 
+	<?php if ( $title ): ?>
 	<div class="container">
 		<h1 class="mt-3 mt-sm-4 mt-md-5 mb-3"><?php echo $title; ?></h1>
 
@@ -263,6 +265,7 @@ function get_header_media_markup( $obj, $videos, $images ) {
 		<p class="lead mb-4 mb-md-5"><?php echo $subtitle; ?></p>
 		<?php endif; ?>
 	</div>
+	<?php endif; ?>
 <?php
 	return ob_get_clean();
 }

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -79,15 +79,13 @@ function get_header_videos( $obj ) {
 	if ( is_tax() || is_category() || is_tag() ) {
 		$title = $obj->name;
 	}
+	else if ( $obj instanceof WP_Post ) {
+		$title = $post->post_title;
+	}
 
 	// Apply custom header title override, if available
 	if ( $custom_header_title = get_field( 'page_header_title', $field_id ) ) {
 		$title = do_shortcode( $custom_header_title );
-	}
-
-	// Fall back to the post title for post objects
-	if ( !$title && $obj instanceof WP_Post ) {
-		$title = $post->post_title;
 	}
 
 	return wptexturize( $title );

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -8,21 +8,28 @@
  **/
 function get_header_images( $post ) {
 	$retval = array(
-		'header_image'    => get_field( 'page_header_image', $post->ID ),
-		'header_image_xs' => get_field( 'page_header_image_xs', $post->ID )
+		'header_image'    => '',
+		'header_image_xs' => ''
 	);
+
+	if ( $post->post_type === 'degree' ) {
+		$retval = degree_backup_headers( $post );
+	}
+
+	if ( $post_header_image = get_field( 'page_header_image', $post->ID ) ) {
+		$retval['header_image'] = $post_header_image;
+	}
+	if ( $post_header_image_xs = get_field( 'page_header_image_xs', $post->ID ) ) {
+		$retval['header_image_xs'] = $post_header_image_xs;
+	}
 
 	if ( $retval['header_image'] ) {
 		return $retval;
-	} else if( $post->post_type === 'degree' ) {
-		return degree_backup_headers( $post );
 	}
-
 	return false;
 }
 
 function degree_backup_headers( $post ) {
-
 	$college = wp_get_post_terms( $post->ID, 'colleges' );
 
 	if ( is_array( $college ) ) {
@@ -34,6 +41,7 @@ function degree_backup_headers( $post ) {
 		'header_image_xs' => get_field( 'page_header_image_xs', 'colleges_' . $college->term_id )
 	);
 }
+
 
 /**
  * Gets the header video sources for pages.
@@ -52,6 +60,36 @@ function get_header_videos( $post ) {
 	}
 
 	return false;
+}
+
+
+/**
+ * Returns title text for use in the page header.
+ **/
+ function get_header_title( $post ) {
+	$title = '';
+
+	if ( is_404() ) {
+		$title = '404 Not Found';
+	}
+	else {
+		$title = do_shortcode( get_field( 'page_header_title', $post->ID ) );
+	}
+
+	if ( !$title ) {
+		// Fall back to the post title
+		$title = $post->post_title;
+	}
+
+	return wptexturize( $title );
+}
+
+
+/**
+ * Returns subtitle text for use in the page header.
+ **/
+ function get_header_subtitle( $post ) {
+	return wptexturize( do_shortcode( get_field( 'page_header_subtitle', $post->ID ) ) );
 }
 
 
@@ -83,73 +121,150 @@ function get_nav_markup( $image=true ) {
 
 
 /**
- * Returns the markup for page headers.
+ * Returns markup for page header title + subtitles within headers that use a
+ * media background.
  **/
-function get_header_media_markup( $post ) {
-	$page_title = get_post_meta( $post->ID, 'page_header_title', true );
-	$title = ( ! empty( $page_title ) ) ? $page_title : $post->post_title;
-	$subtitle = get_post_meta( $post->ID, 'page_header_subtitle', true );
-	$videos = get_header_videos( $post );
-	$images = get_header_images( $post );
+function get_header_content_title_subtitle( $post ) {
+	$title = get_header_title( $post );
+	$subtitle = get_header_subtitle( $post );
+
+	ob_start();
+?>
+	<div class="header-content-inner d-flex h-75 align-items-center">
+		<div class="container">
+			<div class="d-inline-block bg-primary-t-1">
+				<h1 class="header-title"><?php echo $title; ?></h1>
+			</div>
+			<?php if ( $subtitle ) : ?>
+			<div class="clearfix"></div>
+			<div class="d-inline-block bg-inverse">
+				<div class="header-subtitle"><?php echo $subtitle; ?></div>
+			</div>
+			<?php endif; ?>
+		</div>
+	</div>
+<?php
+	return ob_get_clean();
+}
+
+
+/**
+ * Returns markup for page header custom content within headers that use a
+ * media background.
+ **/
+function get_header_content_custom( $post ) {
+	$content = get_field( 'page_header_content', $post->ID );
+
+	ob_start();
+
+	if ( $content ) {
+		echo $content;
+	}
+
+	return ob_get_clean();
+}
+
+
+/**
+ * Returns the markup for page headers with media backgrounds.
+ **/
+function get_header_media_markup( $post, $videos, $images ) {
+	$videos     = $videos ?: get_header_videos( $post );
+	$images     = $images ?: get_header_images( $post );
 	$video_loop = get_field( 'page_header_video_loop', $post->ID );
 
 	ob_start();
 
-	if ( $images || $videos ) :
-		$header_height = get_field( 'page_header_height', $post->ID );
+	$header_height = get_field( 'page_header_height', $post->ID );
 ?>
-		<div class="header-media <?php echo $header_height; ?> media-background-container mb-0 d-flex flex-column">
-			<?php
-			if ( $videos ) {
-				echo get_media_background_video( $videos, $video_loop );
+	<div class="header-media <?php echo $header_height; ?> media-background-container mb-0 d-flex flex-column">
+		<?php
+		// Display the media background (video + picture)
+
+		if ( $videos ) {
+			echo get_media_background_video( $videos, $video_loop );
+		}
+		if ( $images ) {
+			$bg_image_srcs = array();
+			switch ( $header_height ) {
+				case 'header-media-fullscreen':
+					$bg_image_srcs = get_media_background_picture_srcs( null, $images['header_image'], 'bg-img' );
+					$bg_image_src_xs = get_media_background_picture_srcs( $images['header_image_xs'], null, 'header-img' );
+
+					if ( isset( $bg_image_src_xs['xs'] ) ) {
+						$bg_image_srcs['xs'] = $bg_image_src_xs['xs'];
+					}
+
+					break;
+				default:
+					$bg_image_srcs = get_media_background_picture_srcs( $images['header_image_xs'], $images['header_image'], 'header-img' );
+					break;
 			}
-			if ( $images ) {
-				$bg_image_srcs = array();
-				switch ( $header_height ) {
-					case 'header-media-fullscreen':
-						$bg_image_src_xs = get_media_background_picture_srcs( $images['header_image_xs'], null, 'header-img' );
-						$bg_image_srcs_sm = get_media_background_picture_srcs( null, $images['header_image'], 'bg-img' );
-						$bg_image_srcs = array_merge( $bg_image_src_xs, $bg_image_srcs_sm );
-						break;
-					default:
-						$bg_image_srcs = get_media_background_picture_srcs( $images['header_image_xs'], $images['header_image'], 'header-img' );
-						break;
+			echo get_media_background_picture( $bg_image_srcs );
+		}
+		?>
+
+		<?php
+		// Display the site nav
+		echo get_nav_markup();
+		?>
+
+		<?php
+		// Display the inner header contents
+		?>
+		<div class="header-content">
+			<div class="header-content-flexfix">
+				<?php
+				if ( get_field( 'page_header_content_type', $post->ID ) === 'title_subtitle' ) {
+					echo get_header_content_title_subtitle( $post );
 				}
-				echo get_media_background_picture( $bg_image_srcs );
-			}
-			?>
-			<?php echo get_nav_markup(); ?>
-			<div class="header-content">
-				<div class="header-content-flexfix">
-					<div class="header-content-inner d-flex h-75 align-items-center">
-						<div class="container">
-							<div class="d-inline-block bg-primary-t-1">
-								<h1 class="header-title"><?php echo $title ?></h1>
-							</div>
-							<?php if ( $subtitle ) : ?>
-							<div class="clearfix"></div>
-							<div class="d-inline-block bg-inverse">
-								<div class="header-subtitle"><?php echo do_shortcode( $subtitle ); ?></div>
-							</div>
-							<?php endif; ?>
-						</div>
-					</div>
-				</div>
+				else {
+					echo get_header_content_custom( $post );
+				}
+				?>
 			</div>
-	<?php else : ?>
-		<?php echo get_nav_markup( false ); ?>
-		<div class="container">
-			<h1><?php the_title(); ?></h1>
 		</div>
+	</div>
 <?php
-	endif;
+	return ob_get_clean();
+}
+
+
+/**
+ * Returns the default markup for page headers without a media background.
+ **/
+ function get_header_default_markup( $post ) {
+	$title    = get_header_title( $post );
+	$subtitle = get_header_subtitle( $post );
+
+	ob_start();
+?>
+	<?php echo get_nav_markup(); ?>
+
+	<div class="container">
+		<h1 class="mt-3 mt-sm-4 mt-md-5 mb-3"><?php echo $title; ?></h1>
+
+		<?php if ( $subtitle ): ?>
+		<p class="lead mb-4 mb-md-5"><?php echo $subtitle; ?></p>
+		<?php endif; ?>
+	</div>
+<?php
 	return ob_get_clean();
 }
 
 
 function get_header_markup() {
 	global $post;
-	echo get_header_media_markup( $post );
+
+	$videos = get_header_videos( $post );
+	$images = get_header_images( $post );
+
+	if ( $videos || $images ) {
+		echo get_header_media_markup( $post, $videos, $images );
+	}
+	else {
+		echo get_header_default_markup( $post );
+	}
 }
 
 ?>

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -45,3 +45,39 @@ function get_theme_mod_or_default( $theme_mod ) {
 	}
 	return $mod;
 }
+
+
+/**
+ * Given a WP_Term or WP_Post object, returns the relevant object ID property
+ * or null.
+ **/
+function get_object_id( $obj ) {
+	$obj_id = null;
+
+	if ( $obj instanceof WP_Post ) {
+		$obj_id = $obj->ID;
+	}
+	else if ( $obj instanceof WP_Term ) {
+		$obj_id = $obj->term_id;
+	}
+
+	return $obj_id;
+}
+
+
+/**
+ * Given a WP_Term or WP_Post object, returns the relevant $post_id argument
+ * for ACF field retrieval/modification functions (e.g. get_field()) or null.
+ **/
+function get_object_field_id( $obj ) {
+	$field_id = null;
+
+	if ( $obj instanceof WP_Post ) {
+		$field_id = $obj->ID;
+	}
+	else if ( $obj instanceof WP_Term ) {
+		$field_id = $obj->taxonomy . '_' . $obj->term_id;
+	}
+
+	return $field_id;
+}


### PR DESCRIPTION
- Adds the ability to insert arbitrary custom content into a page header in lieu of a standard title + subtitle.
- Adds an extra -xs breakpoint header image fallback check (from Colleges-Theme); a cropped version of the -sm+ header image will be used if it's available and no -xs-specific image is set
- Updated header functions to account for either a post object or term object being passed to them.  Added a couple of utility functions: one that returns a relevant object ID property (`get_object_id()`) and one that returns a ID value to pass to ACF-specific functions for fetching field data (`get_object_field_id()`).  See https://www.advancedcustomfields.com/resources/get_field/ ("Get a value from different objects").  Fixes issues with college pages displaying the first assigned post title instead of the college name in the header.
- Broke out header-specific functions into more discrete chunks (similar to Colleges-Theme); for instance, `get_header_media_markup()` no longer handles displaying of fallback header markup when no media backgrounds are available
- Fixed navbar toggle button positioning classes