### PR TITLE
V3 media background fixes

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1049,7 +1049,7 @@
             },
             {
                 "key": "field_590ca453f6655",
-                "label": "Header Size and Positioning",
+                "label": "Header Size",
                 "name": "",
                 "type": "tab",
                 "instructions": "",
@@ -1086,104 +1086,6 @@
                 "default_value": "header-media-default",
                 "layout": "vertical",
                 "return_format": "value"
-            },
-            {
-                "key": "field_5a1c45076e658",
-                "label": "Header Media Sizing (-sm+)",
-                "name": "page_header_media_fit",
-                "type": "select",
-                "instructions": "Specify how the header image\/video should be stretched or adjusted to fit within the header at the -sm breakpoint and up.  In most cases, this should be set to \"Cover\".",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "50",
-                    "class": "",
-                    "id": ""
-                },
-                "choices": {
-                    "object-fit-cover": "Cover",
-                    "object-fit-contain": "Contain",
-                    "object-fit-fill": "Fill",
-                    "object-fit-scale-down": "Scale Down",
-                    "object-fit-none": "None"
-                },
-                "default_value": [
-                    "object-fit-cover"
-                ],
-                "allow_null": 0,
-                "multiple": 0,
-                "ui": 0,
-                "ajax": 0,
-                "return_format": "value",
-                "placeholder": ""
-            },
-            {
-                "key": "field_5a1c468c6e659",
-                "label": "Header Media Sizing (-xs)",
-                "name": "page_header_media_fit_xs",
-                "type": "select",
-                "instructions": "Specify how the header image\/video should be stretched or adjusted to fit within the header at the -xs breakpoint.  In most cases, this should be set to \"Cover\".",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "50",
-                    "class": "",
-                    "id": ""
-                },
-                "choices": {
-                    "object-fit-cover": "Cover",
-                    "object-fit-contain": "Contain",
-                    "object-fit-fill": "Fill",
-                    "object-fit-scale-down": "Scale Down",
-                    "object-fit-none": "None"
-                },
-                "default_value": [
-                    "object-fit-cover"
-                ],
-                "allow_null": 0,
-                "multiple": 0,
-                "ui": 0,
-                "ajax": 0,
-                "return_format": "value",
-                "placeholder": ""
-            },
-            {
-                "key": "field_5a1c46e46e65b",
-                "label": "Header Media Positioning (-sm+)",
-                "name": "page_header_media_position",
-                "type": "text",
-                "instructions": "How the header image\/video should be positioned horizontally and vertically within the header at the -sm breakpoint and up.  See <a href=\"https:\/\/developer.mozilla.org\/en-US\/docs\/Web\/CSS\/object-position\" target=\"_blank\">https:\/\/developer.mozilla.org\/en-US\/docs\/Web\/CSS\/object-position<\/a> for example usage and possible values.\r\n\r\nMedia is centered horizontally and vertically by default.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "50",
-                    "class": "",
-                    "id": ""
-                },
-                "default_value": "",
-                "placeholder": "e.g. \"center center\" or \"40% 60%\"",
-                "prepend": "",
-                "append": "",
-                "maxlength": ""
-            },
-            {
-                "key": "field_5a1c48b36e65e",
-                "label": "Header Media Positioning (-xs)",
-                "name": "page_header_media_position_xs",
-                "type": "text",
-                "instructions": "How the header image\/video should be positioned horizontally and vertically within the header at the -xs breakpoint.  See <a href=\"https:\/\/developer.mozilla.org\/en-US\/docs\/Web\/CSS\/object-position\" target=\"_blank\">https:\/\/developer.mozilla.org\/en-US\/docs\/Web\/CSS\/object-position<\/a> for example usage and possible values.\r\n\r\nMedia is centered horizontally and vertically by default.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "50",
-                    "class": "",
-                    "id": ""
-                },
-                "default_value": "",
-                "placeholder": "e.g. \"center center\" or \"40% 60%\"",
-                "prepend": "",
-                "append": "",
-                "maxlength": ""
             },
             {
                 "key": "field_590ca625f6657",

--- a/functions.php
+++ b/functions.php
@@ -87,84 +87,17 @@ function get_media_background_picture_srcs( $attachment_xs_id, $attachment_sm_id
 
 
 /**
- * Returns an array of object-fit classes for a media background's sources by
- * breakpoint.
- *
- * @param string $xs_override Object-fit class to be used at the -xs breakpoint
- * @param string $sm_override Object-fit class to be used at the -sm breakpoint and up
- * @return array
- **/
-function get_media_background_object_fits( $xs_override=null, $sm_override=null ) {
-	$defaults = array_fill_keys( array( 'xl', 'lg', 'md', 'sm', 'xs', 'fallback' ), 'object-fit-cover' );
-	$overrides = array();
-
-	if ( $sm_override ) {
-		$overrides['xl'] = $sm_override;
-		$overrides['lg'] = $sm_override;
-		$overrides['md'] = $sm_override;
-		$overrides['sm'] = $sm_override;
-		$overrides['fallback'] = $sm_override;
-	}
-
-	if ( $xs_override ) {
-		$overrides['xs'] = $xs_override;
-	}
-
-	return array_merge( $defaults, $overrides );
-}
-
-
-/**
- * Returns an array of object-position values for a media background's sources
- * by breakpoint.
- *
- * @param string $xs_override Object-position value to be used at the -xs breakpoint
- * @param string $sm_override Object-position value to be used at the -sm breakpoint and up
- * @return array
- **/
-function get_media_background_object_positions( $xs_override=null, $sm_override=null ) {
-	$defaults = array_fill_keys( array( 'xl', 'lg', 'md', 'sm', 'xs', 'fallback' ), '50% 50%' );
-	$overrides = array();
-
-	if ( $sm_override ) {
-		$overrides['xl'] = $sm_override;
-		$overrides['lg'] = $sm_override;
-		$overrides['md'] = $sm_override;
-		$overrides['sm'] = $sm_override;
-		$overrides['fallback'] = $sm_override;
-	}
-
-	if ( $xs_override ) {
-		$overrides['xs'] = $xs_override;
-	}
-
-	return array_merge( $defaults, $overrides );
-}
-
-
-/**
  * Returns markup for a media background <picture>.
  *
  * @param array $srcs Array of image urls that correspond to <source> src vals. Expects output from get_media_background_picture_srcs()
- * @param array $object_fits Array of object-fit classes per breakpoint. Expects output from get_media_background_object_fits()
- * @param array $object_positions Array of object-position per breakpoint. Expects output from get_media_background_object_positions()
  * @return string
  **/
-function get_media_background_picture( $srcs, $object_fits, $object_positions ) {
+function get_media_background_picture( $srcs ) {
 	ob_start();
 
 	if ( isset( $srcs['fallback'] ) ) :
 ?>
-	<?php
-	// Define classes for the <picture> element
-	$picture_classes = 'media-background-picture ';
-	if ( !isset( $srcs['xs'] ) ) {
-		// Hide the <picture> element at -xs breakpoint when no mobile image
-		// is available
-		$picture_classes .= 'hidden-xs-down';
-	}
-	?>
-	<picture class="<?php echo $picture_classes; ?>">
+	<picture class="media-background-picture">
 		<?php if ( isset( $srcs['xl'] ) ) : ?>
 		<source srcset="<?php echo $srcs['xl']; ?>" media="(min-width: 1200px)">
 		<?php endif; ?>
@@ -181,12 +114,12 @@ function get_media_background_picture( $srcs, $object_fits, $object_positions ) 
 		<source srcset="<?php echo $srcs['sm']; ?>" media="(min-width: 576px)">
 		<?php endif; ?>
 
-		<img class="media-background <?php echo $object_fits['fallback']; ?>" src="<?php echo $srcs['fallback']; ?>" style="object-position: <?php echo $object_positions['fallback']; ?>;" data-object-position="<?php echo $object_positions['fallback']; ?>" alt="">
-	</picture>
+		<?php if ( isset( $srcs['xs'] ) ) : ?>
+		<source srcset="<?php echo $srcs['xs']; ?>" media="(max-width: 575px)">
+		<?php endif; ?>
 
-	<?php if ( isset( $srcs['xs'] ) ) : ?>
-	<img class="media-background hidden-sm-up <?php echo $object_fits['xs']; ?>" src="<?php echo $srcs['xs']; ?>" style="object-position: <?php echo $object_positions['xs']; ?>;" data-object-position="<?php echo $object_positions['xs']; ?>" alt="">
-	<?php endif; ?>
+		<img class="media-background object-fit-cover" src="<?php echo $srcs['fallback']; ?>" alt="">
+	</picture>
 <?php
 	endif;
 
@@ -204,14 +137,12 @@ function get_media_background_picture( $srcs, $object_fits, $object_positions ) 
  * Note: we never display autoplay videos at the -xs breakpoint.
  *
  * @param array $videos Array of video urls that correspond to <source> src vals
- * @param string $object_fit Object-fit class for the video (sm+)
- * @param string $object_position Object-position value for the video (sm+)
  * @return string
  **/
-function get_media_background_video( $videos, $loop=false, $object_fit, $object_position ) {
+function get_media_background_video( $videos, $loop=false ) {
 	ob_start();
 ?>
-	<video class="hidden-xs-down media-background media-background-video <?php echo $object_fit; ?>" style="object-position: <?php echo $object_position; ?>;" data-object-position="<?php echo $object_position; ?>" autoplay muted <?php if ( $loop ) { ?>loop<?php } ?>>
+	<video class="hidden-xs-down media-background media-background-video object-fit-cover" autoplay muted <?php if ( $loop ) { ?>loop<?php } ?>>
 		<?php if ( isset( $videos['webm'] ) ) : ?>
 		<source src="<?php echo $videos['webm']; ?>" type="video/webm">
 		<?php endif; ?>
@@ -237,8 +168,6 @@ function add_section_markup_before( $content, $section, $class, $title, $section
 	$bg_image_sm_id = get_field( 'section_background_image', $section->ID );    // -sm+
 	$bg_image_xs_id = get_field( 'section_background_image_xs', $section->ID ); // -xs only
 	$bg_images = get_media_background_picture_srcs( $bg_image_xs_id, $bg_image_sm_id, 'bg-img' );
-	$bg_object_fits = get_media_background_object_fits();
-	$bg_object_positions = get_media_background_object_positions();
 
 	// Retrieve color classes/custom definitions
 	$bg_color = get_field( 'section_background_color', $section->ID );
@@ -279,7 +208,7 @@ function add_section_markup_before( $content, $section, $class, $title, $section
 	ob_start();
 ?>
 	<section <?php echo $section_id; ?>class="<?php echo $section_classes; ?>" style="<?php echo $style_attrs; ?>"<?php echo $title; ?>>
-	<?php echo get_media_background_picture( $bg_images, $bg_object_fits, $bg_object_positions ); ?>
+	<?php echo get_media_background_picture( $bg_images ); ?>
 <?php
 	return ob_get_clean();
 }

--- a/functions.php
+++ b/functions.php
@@ -166,27 +166,27 @@ function get_media_background_picture( $srcs, $object_fits, $object_positions ) 
 	?>
 	<picture class="<?php echo $picture_classes; ?>">
 		<?php if ( isset( $srcs['xl'] ) ) : ?>
-		<source class="media-background <?php echo $object_fits['xl']; ?>" srcset="<?php echo $srcs['xl']; ?>" style="object-position: <?php echo $object_positions['xl']; ?>;" data-object-position="<?php echo $object_positions['xl']; ?>" media="(min-width: 1200px)">
+		<source srcset="<?php echo $srcs['xl']; ?>" media="(min-width: 1200px)">
 		<?php endif; ?>
 
 		<?php if ( isset( $srcs['lg'] ) ) : ?>
-		<source class="media-background <?php echo $object_fits['lg']; ?>" srcset="<?php echo $srcs['lg']; ?>" style="object-position: <?php echo $object_positions['lg']; ?>;" data-object-position="<?php echo $object_positions['lg']; ?>" media="(min-width: 992px)">
+		<source srcset="<?php echo $srcs['lg']; ?>" media="(min-width: 992px)">
 		<?php endif; ?>
 
 		<?php if ( isset( $srcs['md'] ) ) : ?>
-		<source class="media-background <?php echo $object_fits['md']; ?>" srcset="<?php echo $srcs['md']; ?>" style="object-position: <?php echo $object_positions['md']; ?>;" data-object-position="<?php echo $object_positions['md']; ?>" media="(min-width: 768px)">
+		<source srcset="<?php echo $srcs['md']; ?>" media="(min-width: 768px)">
 		<?php endif; ?>
 
 		<?php if ( isset( $srcs['sm'] ) ) : ?>
-		<source class="media-background <?php echo $object_fits['sm']; ?>" srcset="<?php echo $srcs['sm']; ?>" style="object-position: <?php echo $object_positions['sm']; ?>;" data-object-position="<?php echo $object_positions['sm']; ?>" media="(min-width: 576px)">
-		<?php endif; ?>
-
-		<?php if ( isset( $srcs['xs'] ) ) : ?>
-		<source class="media-background <?php echo $object_fits['xs']; ?>" srcset="<?php echo $srcs['xs']; ?>" style="object-position: <?php echo $object_positions['xs']; ?>;" data-object-position="<?php echo $object_positions['xs']; ?>" media="(max-width: 575px)">
+		<source srcset="<?php echo $srcs['sm']; ?>" media="(min-width: 576px)">
 		<?php endif; ?>
 
 		<img class="media-background <?php echo $object_fits['fallback']; ?>" src="<?php echo $srcs['fallback']; ?>" style="object-position: <?php echo $object_positions['fallback']; ?>;" data-object-position="<?php echo $object_positions['fallback']; ?>" alt="">
 	</picture>
+
+	<?php if ( isset( $srcs['xs'] ) ) : ?>
+	<img class="media-background hidden-sm-up <?php echo $object_fits['xs']; ?>" src="<?php echo $srcs['xs']; ?>" style="object-position: <?php echo $object_positions['xs']; ?>;" data-object-position="<?php echo $object_positions['xs']; ?>" alt="">
+	<?php endif; ?>
 <?php
 	endif;
 

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -215,8 +215,6 @@ function get_header_media_markup( $obj, $videos, $images ) {
 	$header_content_type = get_field( 'page_header_content_type', $field_id );
 	$header_height       = get_field( 'page_header_height', $field_id );
 	$exclude_nav         = get_field( 'page_header_exclude_nav', $field_id );
-	$object_fits         = get_media_background_object_fits( get_field( 'page_header_media_fit_xs', $field_id ), get_field( 'page_header_media_fit', $field_id ) );
-	$object_positions    = get_media_background_object_positions( get_field( 'page_header_media_position_xs', $field_id ), get_field( 'page_header_media_position', $field_id ) );
 
 	ob_start();
 ?>
@@ -227,7 +225,7 @@ function get_header_media_markup( $obj, $videos, $images ) {
 				// Display the media background (video + picture)
 
 				if ( $videos ) {
-					echo get_media_background_video( $videos, $video_loop, $object_fits['sm'], $object_positions['sm'] );
+					echo get_media_background_video( $videos, $video_loop );
 				}
 				if ( $images ) {
 					$bg_image_srcs = array();
@@ -245,7 +243,7 @@ function get_header_media_markup( $obj, $videos, $images ) {
 							$bg_image_srcs = get_media_background_picture_srcs( $images['header_image_xs'], $images['header_image'], 'header-img' );
 							break;
 					}
-					echo get_media_background_picture( $bg_image_srcs, $object_fits, $object_positions );
+					echo get_media_background_picture( $bg_image_srcs );
 				}
 				?>
 			</div>


### PR DESCRIPTION
- Removed object-fit and object-position ACF fields for page headers, since they can't be fully applied properly.  Reverted all media backgrounds to use object-fit: cover and centered media.
- Removed object-fit and object-position styles from `<picture>` `<source>`'s, since they have no effect.
- Removed .hidden-xs-down class on `<picture>` elems when no -xs image is available...I'd initially added this to prevent loading large images on mobile, but I think this is going to do more harm than good.  We will rarely, if ever, not have a mobile image to fall back to.