### PR TITLE
Phonebook fixes

### DIFF
--- a/includes/phonebook-functions.php
+++ b/includes/phonebook-functions.php
@@ -28,7 +28,9 @@ function get_phonebook_results( $query ) {
 	if ( is_array( $response ) ) {
 		$results = json_decode( wp_remote_retrieve_body( $response ) );
 
-		$results = $results->results;
+		// Force cast empty values to array;
+		// the search service can sometimes return null here
+		$results = $results->results ?: array();
 	}
 
 	if ( empty( $results ) ) {

--- a/includes/phonebook-functions.php
+++ b/includes/phonebook-functions.php
@@ -256,7 +256,8 @@ function format_phonebook_result( $result ) {
 						<?php else : ?>
 							<span class="name"><?php echo $person->name; ?></span>
 						<?php endif; ?>
-						<?php if ( $person->phone ) : ?>
+
+						<?php if ( $person->phone && $person->phone !== '000-000-0000' ) : ?>
 							<span class="phone"><a href="tel:<?php echo str_replace( '-', '', $person->phone ); ?>"><?php echo $person->phone; ?></a></span>
 						<?php endif; ?>
 					</li>

--- a/includes/phonebook-functions.php
+++ b/includes/phonebook-functions.php
@@ -336,7 +336,7 @@ function format_phonebook_result_location( $result, $is_dept, $is_org, $is_group
 	<?php endif; ?>
 	<?php if ( $result->postal ) : ?>
 		<span class="postal d-block">
-			Zip: <?php echo $result->postal; ?>
+			ZIP: <?php echo $result->postal; ?>
 		</span>
 	<?php endif; ?>
 <?php

--- a/page-phonebook.php
+++ b/page-phonebook.php
@@ -1,11 +1,16 @@
-<?php get_header();
+<?php
 /**
  * The page template for the phonebook
  **/
+?>
+
+<?php get_header(); ?>
+
+<?php
 $query = isset( $_GET['query'] ) ? $_GET['query'] : '';
 $results = get_phonebook_results( $query );
-
 ?>
+
 <div class="container mt-md-4 mb-4 mb-sm-5 pb-md-5">
 	<form id="phonebook-search">
 		<div class="input-group">
@@ -16,7 +21,10 @@ $results = get_phonebook_results( $query );
 			</span>
 		</div>
 	</form>
+
+	<?php if ( $query ): ?>
 	<div class="phonebook-results my-4 my-md-5">
+
 		<?php if ( count( $results ) === 0 ) : ?>
 			<div class="alert alert-warning">
 				<p class="mb-0">No results were found.</p>
@@ -28,6 +36,9 @@ $results = get_phonebook_results( $query );
 			}
 			?>
 		<?php endif; ?>
+
 	</div>
+	<?php endif; ?>
 </div>
+
 <?php get_footer(); ?>

--- a/page-phonebook.php
+++ b/page-phonebook.php
@@ -6,7 +6,7 @@ $query = isset( $_GET['query'] ) ? $_GET['query'] : '';
 $results = get_phonebook_results( $query );
 
 ?>
-<div class="container mb-5 pb-md-5">
+<div class="container mt-md-4 mb-4 mb-sm-5 pb-md-5">
 	<form id="phonebook-search">
 		<div class="input-group">
 			<label for="phonebook-search-query" class="sr-only">Search Organizations, Departments, and People at UCF</label>
@@ -16,16 +16,18 @@ $results = get_phonebook_results( $query );
 			</span>
 		</div>
 	</form>
-	<?php if ( is_array( $results ) ) : ?>
-	<div class="phonebook-results my-5">
+	<div class="phonebook-results my-4 my-md-5">
 		<?php if ( count( $results ) === 0 ) : ?>
-			<p class="text-bold">No results were found.</p>
-		<?php else :
+			<div class="alert alert-warning">
+				<p class="mb-0">No results were found.</p>
+			</div>
+		<?php else: ?>
+			<?php
 			foreach( $results as $result ) {
 				echo format_phonebook_result( $result );
 			}
-			endif; ?>
+			?>
+		<?php endif; ?>
 	</div>
-	<?php endif; ?>
 </div>
 <?php get_footer(); ?>

--- a/page-phonebook.php
+++ b/page-phonebook.php
@@ -6,7 +6,7 @@ $query = isset( $_GET['query'] ) ? $_GET['query'] : '';
 $results = get_phonebook_results( $query );
 
 ?>
-<div class="container">
+<div class="container mb-5 pb-md-5">
 	<form id="phonebook-search">
 		<div class="input-group">
 			<label for="phonebook-search-query" class="sr-only">Search Organizations, Departments, and People at UCF</label>


### PR DESCRIPTION
A little bit of overdue TLC for the phonebook.

- Force `$results` to be cast as an array if a `null` value is returned by the search service in `get_phonebook_results()`. Fixes various issues with subsequent results filtering functions that expect the value to be an array.
- Updated staff results to not include `000-000-0000` phone numbers
- Adds whitespace adjustments above and below the phonebook page's container and search form
- Wraps the 'no results found' message in an alert for better visibility
- Updated "ZIP" label for dept/org's to be all-caps

Resolves #165 and should resolve #160.