### PR TITLE
Support per-alert URLs and CTAs

### DIFF
--- a/includes/ucf-alert-functions.php
+++ b/includes/ucf-alert-functions.php
@@ -37,7 +37,7 @@ if ( class_exists( 'UCF_Alert_Common' ) ) {
 		<div class="container">
 			<div class="row no-gutters">
 				<div class="col col-lg-8 offset-lg-2">
-					<a class="ucf-alert-content" href="<?php echo UCF_Alert_Config::get_option_or_default( 'alerts_url' ); ?>">
+					<a class="ucf-alert-content">
 						<div class="row no-gutters">
 							<div class="col-auto">
 								<span class="ucf-alert-icon fa" aria-hidden="true"></span>
@@ -45,9 +45,7 @@ if ( class_exists( 'UCF_Alert_Common' ) ) {
 							<div class="col">
 								<strong class="ucf-alert-title h4"></strong>
 								<div class="ucf-alert-body"></div>
-								<div class="ucf-alert-cta">
-									<?php echo UCF_Alert_Config::get_option_or_default( 'cta' ); ?>
-								</div>
+								<div class="ucf-alert-cta"></div>
 							</div>
 						</div>
 					</a>


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Updated the 'faicon' alert layout to remove references to deleted UCF Alert Plugin options and support per-alert URLs and call-to-action text.

Requires https://github.com/UCF/alert/pull/6 and https://github.com/UCF/UCF-Alert-Plugin/pull/4

See also: https://github.com/UCF/UCF-WordPress-Theme/pull/56

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Required for support with future versions of the alert site and UCF Alert Plugin.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
