### PR TITLE
Added hook that forces empty college terms to appear in the college sitemap generated by Yoast

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -464,3 +464,21 @@ function remove_yoast_meta_boxes() {
 
 add_action( 'add_meta_boxes', 'remove_yoast_meta_boxes' );
 
+
+/**
+ * Ensure that empty College terms appear in Yoast's generated
+ * sitemap for Colleges.
+ *
+ * @since v3.2.4
+ * @author Jo Dickson
+ * @param bool $hide_empty Yoast default setting (defaults to true)
+ * @param array $taxonomy_names Array of names for the taxonomies being processed.
+ */
+function yoast_sitemap_empty_terms( $hide_empty, $taxonomies ) {
+	if ( $taxonomies === array( 'colleges' ) ) {
+		$hide_empty = false;
+	}
+	return $hide_empty;
+}
+
+add_filter( 'wpseo_sitemap_exclude_empty_terms', 'yoast_sitemap_empty_terms', 10, 2 );

--- a/includes/config.php
+++ b/includes/config.php
@@ -471,8 +471,9 @@ add_action( 'add_meta_boxes', 'remove_yoast_meta_boxes' );
  *
  * @since v3.2.4
  * @author Jo Dickson
- * @param bool $hide_empty Yoast default setting (defaults to true)
+ * @param bool $hide_empty Yoast default setting for (defaults to true)
  * @param array $taxonomy_names Array of names for the taxonomies being processed.
+ * @return bool Whether or not the taxonomy should be queried with empty terms
  */
 function yoast_sitemap_empty_terms( $hide_empty, $taxonomies ) {
 	if ( $taxonomies === array( 'colleges' ) ) {


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Because the Burnett Honors College term has no degree posts assigned to it, it gets excluded by default in Yoast's generated College taxonomy sitemap.  This update ensures the Honors term page is always encluded in this sitemap.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
