### PR TITLE
Corrected bug that causees incorrect grouping of results

### DIFF
--- a/includes/phonebook-functions.php
+++ b/includes/phonebook-functions.php
@@ -127,8 +127,8 @@ function phonebook_deduplicate_staff( $results ) {
 			foreach( $results as $_key => $_result ) {
 				// Deduplicate on email
 				if (
-					( $result->email !== null ) &&
-					( $_result->email !== null ) &&
+					( ! empty( $result->email ) ) &&
+					( ! empty( $_result->email ) ) &&
 					( $result !== $_result ) &&
 					( $result->email === $_result->email )
 				) {


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Corrects a bug where non-duplicate staff results were being treated as duplicate because there was no email address set on the records.

**Motivation and Context**
We only want records tied together when they have matching emails. Two records with no email shouldn't be treated as a match.

**How Has This Been Tested?**
Changes are available in dev for review.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
