### PR TITLE
Add full-width degree content field

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -589,7 +589,7 @@
         "fields": [
             {
                 "key": "field_5df8fb1d7bbc1",
-                "label": "Full Width Content - Bottom of Page",
+                "label": "Full-Width Content - Bottom of Page",
                 "name": "degree_full_width_content_bottom",
                 "type": "wysiwyg",
                 "instructions": "Content placed here will be displayed full-width below the two-column layout and the breadcrumbs, and before the UCF Colleges section.",

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -584,6 +584,48 @@
         "description": ""
     },
     {
+        "key": "group_5df8fb174faec",
+        "title": "Degree Content Fields",
+        "fields": [
+            {
+                "key": "field_5df8fb1d7bbc1",
+                "label": "Full Width Content - Bottom of Page",
+                "name": "degree_full_width_content_bottom",
+                "type": "wysiwyg",
+                "instructions": "Content placed here will be displayed full-width below the two-column layout and the breadcrumbs, and before the UCF Colleges section.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "tabs": "all",
+                "toolbar": "full",
+                "media_upload": 1,
+                "delay": 0
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "degree"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": true,
+        "description": ""
+    },
+    {
         "key": "group_58fa427b4efb7",
         "title": "Degree Fields",
         "fields": [

--- a/single-degree.php
+++ b/single-degree.php
@@ -101,6 +101,12 @@
 	<?php echo $breadcrumbs; ?>
 </div>
 
+<?php
+if ( isset( $post_meta['degree_full_width_content_bottom'] ) && ! empty( $post_meta['degree_full_width_content_bottom'] ) ) {
+	echo apply_filters( 'the_content', $post_meta['degree_full_width_content_bottom'] );
+}
+?>
+
 <?php echo get_colleges_grid( $college ); ?>
 
 <?php get_footer(); ?>


### PR DESCRIPTION
**Description**
Adds a 'Degree Content Fields' ACF group with a 'Full-Width Content - Bottom of Page' field that is used to insert custom content below the degree content and breadcrumbs.

**Motivation and Context**
This could be used to place specific messaging or callouts on individual degree pages. For example, Roger talked previously about placing callouts to the new Aerospace page on related degrees.


**How Has This Been Tested?**
Updates are in dev.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
