### PR TITLE
Add Sidebar Content ACF Field

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -588,6 +588,57 @@
         "title": "Degree Content Fields",
         "fields": [
             {
+                "key": "field_5dfa8794d5761",
+                "label": "Sidebar Content",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_5dfa86409fa89",
+                "label": "Sidebar Content - Bottom",
+                "name": "degree_sidebar_content_bottom",
+                "type": "wysiwyg",
+                "instructions": "Content placed here will be displayed at the bottom of the sidebar, under existing content.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "tabs": "all",
+                "toolbar": "full",
+                "media_upload": 1,
+                "delay": 0
+            },
+            {
+                "key": "field_5dfa87a4d5762",
+                "label": "Full-Width Content",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
                 "key": "field_5df8fb1d7bbc1",
                 "label": "Full-Width Content - Bottom of Page",
                 "name": "degree_full_width_content_bottom",

--- a/single-degree.php
+++ b/single-degree.php
@@ -76,6 +76,12 @@
 			<?php endif; ?>
 
 			<?php echo get_degree_tuition_markup( $post_meta ); ?>
+
+			<?php
+			if ( isset( $post_meta['degree_sidebar_content_bottom'] ) && ! empty( $post_meta['degree_sidebar_content_bottom'] ) ) {
+				echo apply_filters( 'the_content', $post_meta['degree_sidebar_content_bottom'] );
+			}
+			?>
 		</div>
 	</div>
 


### PR DESCRIPTION
**Description**
Groups the Degree Content fields into tabs for better organization (let me know if you have alternate naming suggestions) and creates a `degree_sidebar_content_bottom` field and displayed content that's inserted into that field at the bottom of all other sidebar content.

**Motivation and Context**
In order to place custom content/callouts in the sidebar.

**How Has This Been Tested?**
Udpates in dev.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
