### PR TITLE
Adjust Degree page's right-hand column spacing

### DIFF
--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -144,7 +144,7 @@ function ucf_tuition_fees_degree_layout( $resident, $nonresident ) {
 			<a class="nav-link" data-toggle="tab" href="#out-of-state" role="tab">Out of State</a>
 		</li>
 	</ul>
-	<div class="tab-content py-4">
+	<div class="tab-content pt-4 mb-4 mb-md-5">
 		<div class="tab-pane active" id="in-state" role="tabpanel">
 			<?php if ( $value_message ) : ?>
 			<?php echo apply_filters( 'the_content', $value_message ); ?>

--- a/single-degree.php
+++ b/single-degree.php
@@ -62,7 +62,7 @@
 			<?php echo main_site_degree_display_subplans( $post->ID ); ?>
 		</div>
 		<div class="col-lg-4 offset-xl-1 mt-4 mt-lg-0">
-			<div class="hidden-md-down mb-4">
+			<div class="hidden-md-down mb-5">
 				<?php echo get_degree_apply_button( $post ); ?>
 				<?php echo get_degree_visit_ucf_button(); ?>
 			</div>


### PR DESCRIPTION
**Description**
See title.

**Motivation and Context**
Fixes an issue where the custom sidebar content looks to be a part of the 'tuition & fees' content, and makes sure that spacing under that is uniform, along with adding spacing under the Apply and Visit buttons in order to separate them from the tuition & fees content as well.

**How Has This Been Tested?**
Updates in dev.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
