### PR TITLE
Add option to set subtitle to an h2

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1072,7 +1072,7 @@
                     ]
                 ],
                 "wrapper": {
-                    "width": "",
+                    "width": "50",
                     "class": "",
                     "id": ""
                 },
@@ -1082,10 +1082,47 @@
                 },
                 "allow_null": 0,
                 "other_choice": 0,
-                "save_other_choice": 0,
                 "default_value": "title",
                 "layout": "vertical",
-                "return_format": "value"
+                "return_format": "value",
+                "save_other_choice": 0
+            },
+            {
+                "key": "field_5dfbc6c075e41",
+                "label": "Subtitle Element",
+                "name": "page_header_subtitle_elem",
+                "type": "radio",
+                "instructions": "Specify if the subtitle should be wrapped in a <code>span<\/code> or <code>h2<\/code> element.  Styling of the title\/subtitle will not be affected by this choice. Defaults to span.",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_59aed971c187c",
+                            "operator": "==",
+                            "value": "title_subtitle"
+                        },
+                        {
+                            "field": "field_5a0e009ff592e",
+                            "operator": "==",
+                            "value": "title"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "50",
+                    "class": "",
+                    "id": ""
+                },
+                "choices": {
+                    "span": "span",
+                    "h2": "h2"
+                },
+                "allow_null": 0,
+                "other_choice": 0,
+                "default_value": "title",
+                "layout": "vertical",
+                "return_format": "value",
+                "save_other_choice": 0
             },
             {
                 "key": "field_59aed93dc187b",

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -134,14 +134,17 @@ function get_header_h1_option( $obj ) {
 }
 
 /**
- * Returns whether the subtitle should be set to a span or h2.
- * Defaults to 'span' if the option isn't set.
- * Returns 'span' if the 'page_header_subtitle' option is set to subtitle.
- * Will force return a different value if the user screwed up (e.g. specified
- * "h2" but didn't provide a subtitle value).
+ * Returns the element to use for the subtitle.
+ * Defaults to 'span' if the option isn't set, returns 'span' if the $h1 is set to subtitle.
+ *
+ * @author Cadie Stockman
+ * @since 3.3.5
+ * @param object $obj | WP_Post object for the post
+ * @param string $h1  | Return value of get_header_h1_option()
+ * @return string | Element to use for the subtitle
  **/
 function get_header_subtitle_elem( $obj, $h1 ) {
-	$field_id = get_object_field_id( $obj );
+	$field_id      = get_object_field_id( $obj );
 	$subtitle      = get_field( 'page_header_subtitle', $field_id ) ?: '';
 	$subtitle_elem = get_field( 'page_header_subtitle_elem', $field_id ) ?: 'span';
 

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -133,6 +133,27 @@ function get_header_h1_option( $obj ) {
 	return $h1;
 }
 
+/**
+ * Returns whether the subtitle should be set to a span or h2.
+ * Defaults to 'span' if the option isn't set.
+ * Returns 'span' if the 'page_header_subtitle' option is set to subtitle.
+ * Will force return a different value if the user screwed up (e.g. specified
+ * "h2" but didn't provide a subtitle value).
+ **/
+function get_header_subtitle_elem( $obj, $h1 ) {
+	$field_id = get_object_field_id( $obj );
+	$subtitle      = get_field( 'page_header_subtitle', $field_id ) ?: '';
+	$subtitle_elem = get_field( 'page_header_subtitle_elem', $field_id ) ?: 'span';
+
+	if ( $h1 === 'subtitle' ) {
+		$subtitle_elem = 'h1';
+	} elseif ( trim( $subtitle ) === '' ) {
+		$subtitle_elem = 'span';
+	}
+
+	return $subtitle_elem;
+}
+
 
 function get_nav_markup( $image=true ) {
 	ob_start();
@@ -171,7 +192,7 @@ function get_header_content_title_subtitle( $obj ) {
 	$subtitle      = get_header_subtitle( $obj );
 	$h1            = get_header_h1_option( $obj );
 	$title_elem    = ( $h1 === 'title' ) ? 'h1' : 'span';
-	$subtitle_elem = ( $h1 === 'subtitle' ) ? 'h1' : 'span';
+	$subtitle_elem = get_header_subtitle_elem( $obj, $h1 );
 
 	ob_start();
 

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -135,7 +135,7 @@ function get_header_h1_option( $obj ) {
 
 /**
  * Returns the element to use for the subtitle.
- * Defaults to 'span' if the option isn't set, returns 'span' if the $h1 is set to subtitle.
+ * Defaults to 'span' if the option isn't set, returns 'h1' if the $h1 is set to subtitle.
  *
  * @author Cadie Stockman
  * @since 3.3.5


### PR DESCRIPTION
**Description**
Adds an ACF radio option in the Header field group that allows the subtitle to be set to an H2. This takes into account whether the "Page h1" field is set to subtitle (if it is, the subtitle element is set to h1 regardless), and if the Subtitle Element field is set to 'h2' but the actual Header Subtitle Text field is empty.

**Motivation and Context**
Will be used on certain degree profile pages in order to set the subtitle as an H2 element.

**How Has This Been Tested?**
Updates in dev.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
