### PR TITLE
Revert "Merge pull request #214 from UCF/subtitle-h2-option"

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1072,7 +1072,7 @@
                     ]
                 ],
                 "wrapper": {
-                    "width": "50",
+                    "width": "",
                     "class": "",
                     "id": ""
                 },
@@ -1082,47 +1082,10 @@
                 },
                 "allow_null": 0,
                 "other_choice": 0,
+                "save_other_choice": 0,
                 "default_value": "title",
                 "layout": "vertical",
-                "return_format": "value",
-                "save_other_choice": 0
-            },
-            {
-                "key": "field_5dfbc6c075e41",
-                "label": "Subtitle Element",
-                "name": "page_header_subtitle_elem",
-                "type": "radio",
-                "instructions": "Specify if the subtitle should be wrapped in a <code>span<\/code> or <code>h2<\/code> element.  Styling of the title\/subtitle will not be affected by this choice. Defaults to span.",
-                "required": 0,
-                "conditional_logic": [
-                    [
-                        {
-                            "field": "field_59aed971c187c",
-                            "operator": "==",
-                            "value": "title_subtitle"
-                        },
-                        {
-                            "field": "field_5a0e009ff592e",
-                            "operator": "==",
-                            "value": "title"
-                        }
-                    ]
-                ],
-                "wrapper": {
-                    "width": "50",
-                    "class": "",
-                    "id": ""
-                },
-                "choices": {
-                    "span": "span",
-                    "h2": "h2"
-                },
-                "allow_null": 0,
-                "other_choice": 0,
-                "default_value": "title",
-                "layout": "vertical",
-                "return_format": "value",
-                "save_other_choice": 0
+                "return_format": "value"
             },
             {
                 "key": "field_59aed93dc187b",

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -133,30 +133,6 @@ function get_header_h1_option( $obj ) {
 	return $h1;
 }
 
-/**
- * Returns the element to use for the subtitle.
- * Defaults to 'span' if the option isn't set, returns 'h1' if the $h1 is set to subtitle.
- *
- * @author Cadie Stockman
- * @since 3.3.5
- * @param object $obj | WP_Post object for the post
- * @param string $h1  | Return value of get_header_h1_option()
- * @return string | Element to use for the subtitle
- **/
-function get_header_subtitle_elem( $obj, $h1 ) {
-	$field_id      = get_object_field_id( $obj );
-	$subtitle      = get_field( 'page_header_subtitle', $field_id ) ?: '';
-	$subtitle_elem = get_field( 'page_header_subtitle_elem', $field_id ) ?: 'span';
-
-	if ( $h1 === 'subtitle' ) {
-		$subtitle_elem = 'h1';
-	} elseif ( trim( $subtitle ) === '' ) {
-		$subtitle_elem = 'span';
-	}
-
-	return $subtitle_elem;
-}
-
 
 function get_nav_markup( $image=true ) {
 	ob_start();
@@ -195,7 +171,7 @@ function get_header_content_title_subtitle( $obj ) {
 	$subtitle      = get_header_subtitle( $obj );
 	$h1            = get_header_h1_option( $obj );
 	$title_elem    = ( $h1 === 'title' ) ? 'h1' : 'span';
-	$subtitle_elem = get_header_subtitle_elem( $obj, $h1 );
+	$subtitle_elem = ( $h1 === 'subtitle' ) ? 'h1' : 'span';
 
 	ob_start();
 


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Reverts #214.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using `h2` elements for subheadings/subtitles is [not recommended in the W3 spec](https://www.w3.org/TR/2016/REC-html51-20161101/common-idioms-without-dedicated-elements.html#subheadings-subtitles-alternative-titles-and-taglines).  Additionally, by allowing subtitles using `h2`s, we end up creating a content structure that is potentially misleading/confusing for users that browse the page by headings.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
