### PR TITLE
Hot Fix: Map Shenanigans 

### DIFF
--- a/single-location.php
+++ b/single-location.php
@@ -3,7 +3,9 @@ get_header();
 the_post();
 
 $lat_lng = $post->meta['ucf_location_lat_lng'];
-$lat_lng_string = ( $lat_lng ) ? $lat_lng["ucf_location_lat"] . "," . $lat_lng["ucf_location_lng"] : "";
+$lat_lng_string = ( isset( $lat_lng['ucf_location_lat'] ) && isset( $lat_lng['ucf_location_lng'] ) )
+	? $lat_lng["ucf_location_lat"] . "," . $lat_lng["ucf_location_lng"]
+	: null;
 $events = ( isset( $post->meta['events_markup'] ) && ! empty( $post->meta['events_markup'] ) ) ? $post->meta['events_markup'] : null;
 
 $featured_image = wp_get_attachment_url( get_post_thumbnail_id( $post->ID ) );

--- a/single-location.php
+++ b/single-location.php
@@ -3,7 +3,7 @@ get_header();
 the_post();
 
 $lat_lng = $post->meta['ucf_location_lat_lng'];
-$lat_lng_string = ( isset( $lat_lng['ucf_location_lat'] ) && isset( $lat_lng['ucf_location_lng'] ) )
+$lat_lng_string = ( ! empty( $lat_lng['ucf_location_lat'] ) && ! empty( $lat_lng['ucf_location_lng'] ) )
 	? $lat_lng["ucf_location_lat"] . "," . $lat_lng["ucf_location_lng"]
 	: null;
 $events = ( isset( $post->meta['events_markup'] ) && ! empty( $post->meta['events_markup'] ) ) ? $post->meta['events_markup'] : null;


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Fixes #218 . Checking to make sure both lat and lng are set before generating a latlng string. This prevents the map from being added to the page with invalid parameters.

**How Has This Been Tested?**
Change is available to review in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
