### PR TITLE
Deregister the frontend block editor stylesheet

### DIFF
--- a/includes/meta.php
+++ b/includes/meta.php
@@ -37,6 +37,15 @@ function enqueue_frontend_assets() {
 	wp_localize_script( 'script', 'UCFEDU', array(
 		'domain' => $site_url['host']
 	) );
+
+	// De-queue Gutenberg block styles if the Classic plugin is enabled.
+	// We do this in lieu of checking on a per-post basis via `has_blocks()`
+	// to ensure non-posts (e.g. college terms) are accounted for as well,
+	// and because we assume that if this plugin is active on this site, we
+	// have no intention of using Gutenberg/blocks anywhere.
+	if ( class_exists( 'Classic_Editor' ) ) {
+		wp_deregister_style( 'wp-block-library' );
+	}
 }
 
 add_action( 'wp_enqueue_scripts', 'enqueue_frontend_assets' );

--- a/includes/meta.php
+++ b/includes/meta.php
@@ -42,11 +42,11 @@ function enqueue_frontend_assets() {
 	// is active and users are not given the option to utilize the block
 	// editor at all.
 	$editor_choice = get_network_option( null, 'classic-editor-replace', get_option( 'classic-editor-replace' ) );
-	$allow_user_editor_choice = get_network_option( null, 'classic-editor-allow-users', get_option( 'classic-editor-allow-users' ) );
+	$allow_user_editor_choice = get_option( 'classic-editor-allow-users' );
 	if (
 		class_exists( 'Classic_Editor' )
 		&& get_option( 'classic-editor-replace' ) === 'classic'
-		&& get_option( 'classic-editor-allow-users' ) === 'disallow'
+		&& get_option( 'classic-editor-allow-users' ) !== 'allow'
 	) {
 		wp_deregister_style( 'wp-block-library' );
 	}

--- a/includes/meta.php
+++ b/includes/meta.php
@@ -45,8 +45,8 @@ function enqueue_frontend_assets() {
 	$allow_user_editor_choice = get_option( 'classic-editor-allow-users' );
 	if (
 		class_exists( 'Classic_Editor' )
-		&& get_option( 'classic-editor-replace' ) === 'classic'
-		&& get_option( 'classic-editor-allow-users' ) !== 'allow'
+		&& $editor_choice !== 'block'
+		&& $allow_user_editor_choice !== 'allow'
 	) {
 		wp_deregister_style( 'wp-block-library' );
 	}

--- a/includes/meta.php
+++ b/includes/meta.php
@@ -38,12 +38,16 @@ function enqueue_frontend_assets() {
 		'domain' => $site_url['host']
 	) );
 
-	// De-queue Gutenberg block styles if the Classic plugin is enabled.
-	// We do this in lieu of checking on a per-post basis via `has_blocks()`
-	// to ensure non-posts (e.g. college terms) are accounted for as well,
-	// and because we assume that if this plugin is active on this site, we
-	// have no intention of using Gutenberg/blocks anywhere.
-	if ( class_exists( 'Classic_Editor' ) ) {
+	// De-queue Gutenberg block styles when the Classic Editor plugin
+	// is active and users are not given the option to utilize the block
+	// editor at all.
+	$editor_choice = get_network_option( null, 'classic-editor-replace', get_option( 'classic-editor-replace' ) );
+	$allow_user_editor_choice = get_network_option( null, 'classic-editor-allow-users', get_option( 'classic-editor-allow-users' ) );
+	if (
+		class_exists( 'Classic_Editor' )
+		&& get_option( 'classic-editor-replace' ) === 'classic'
+		&& get_option( 'classic-editor-allow-users' ) === 'disallow'
+	) {
 		wp_deregister_style( 'wp-block-library' );
 	}
 }


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Prevents the frontend block editor stylesheet (`wp-includes/css/dist/block-library/style.min.css`) from being loaded when the Classic Editor is enabled and users are not given the option to switch between editor types.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoid unnecessary stylesheet inclusions; (slightly) improve performance.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Verifiable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
