### PR TITLE
Fixed "Get Directions" button for single locations with invalid lat+lng coord's

### DIFF
--- a/includes/location-functions.php
+++ b/includes/location-functions.php
@@ -20,8 +20,8 @@ function get_location_html() {
 	$abbr = isset( $post->meta['ucf_location_abbr'] ) ? $post->meta['ucf_location_abbr'] : null;
 	$id = ( isset( $post->meta['ucf_location_id'] ) && $post->meta['ucf_location_id'] !== $post_name  ) ? $post->meta['ucf_location_id'] : null;
 
-	$lat_lng = ( isset( $post->meta['ucf_location_lat_lng'] ) ) ? $post->meta['ucf_location_lat_lng'] : null;
-	$google_map_link = ( $lat_lng ) ? "https://www.google.com/maps?saddr=&daddr=" . $lat_lng["ucf_location_lat"] . "," . $lat_lng["ucf_location_lng"] : "";
+	$lat_lng_str = get_location_latlng_str( $post );
+	$google_map_link = $lat_lng_str ? 'https://www.google.com/maps?saddr=&daddr=' . $lat_lng_str : null;
 
 	ob_start();
 ?>
@@ -36,7 +36,8 @@ function get_location_html() {
 	<?php if( $abbr ) : ?>
 		<div class="row">
 			<div class="col-5 col-md-6 col-lg-7 col-xl-6 text-uppercase font-weight-bold">
-				Abbreviation</div>
+				Abbreviation
+			</div>
 			<div class="col"><?php echo $abbr ?></div>
 		</div>
 	<?php endif; ?>
@@ -48,7 +49,7 @@ function get_location_html() {
 	<?php endif; ?>
 	<?php if( ! empty( $google_map_link ) ) : ?>
 		<a href="<?php echo $google_map_link; ?>" target="_blank" rel="noopener" class="btn btn-outline-secondary btn-sm text-uppercase mb-4 mt-3">
-			<span class="fa fa-location-arrow"></span>
+			<span class="fa fa-location-arrow" aria-hidden="true"></span>
 			Get Directions
 		</a>
 	<?php endif; ?>
@@ -108,7 +109,7 @@ function get_organization_html( $title, $org, $count ) {
 		<?php if( isset( $org['org_departments'] ) && $org['org_departments'] ) : ?>
 			Departments
 			<ul class="pl-4">
-				<?php 
+				<?php
 				foreach( $org['org_departments'] as $dept ) :
 					$dept_name = ( isset( $dept['dept_name'] ) && ! empty( $dept['dept_name'] ) ) ? $dept['dept_name'] . '<br>' : '';
 					$dept_building = ( isset( $dept['dept_building'] ) && ! empty( $dept['dept_building'] ) ) ? $dept['dept_building'] : '';
@@ -208,4 +209,33 @@ function get_header_content_custom_location( $markup, $obj ) {
 }
 
 add_filter( 'get_header_content_title_subtitle', 'get_header_content_custom_location', 10, 2 );
+
+
+/**
+ * Returns a lat+lng string suitable for use in
+ * map embed/link query params.
+ *
+ * @since 3.3.8
+ * @author Jo Dickson
+ * @param object WP_Post object representing the location
+ * @return mixed lat+lng string, or null if no valid lat+lng combination is available
+ */
+function get_location_latlng_str( $location ) {
+	$lat_lng_str = null;
+	if ( ! ( $location instanceof WP_Post ) ) return $lat_lng_str;
+
+	$lat_lng = $location->meta['ucf_location_lat_lng'];
+	if (
+		isset( $lat_lng['ucf_location_lat'] )
+		&& ! empty( $lat_lng['ucf_location_lat'] )
+		&& isset( $lat_lng['ucf_location_lng'] )
+		&& ! empty( $lat_lng['ucf_location_lng'] )
+	) {
+		$lat_lng_str = $lat_lng['ucf_location_lat'] . ',' . $lat_lng['ucf_location_lng'];
+	}
+
+	return $lat_lng_str;
+}
+
+
 ?>

--- a/single-location.php
+++ b/single-location.php
@@ -2,10 +2,7 @@
 get_header();
 the_post();
 
-$lat_lng = $post->meta['ucf_location_lat_lng'];
-$lat_lng_string = ( ! empty( $lat_lng['ucf_location_lat'] ) && ! empty( $lat_lng['ucf_location_lng'] ) )
-	? $lat_lng["ucf_location_lat"] . "," . $lat_lng["ucf_location_lng"]
-	: null;
+$lat_lng_string = get_location_latlng_str( $post );
 $events = ( isset( $post->meta['events_markup'] ) && ! empty( $post->meta['events_markup'] ) ) ? $post->meta['events_markup'] : null;
 
 $featured_image = wp_get_attachment_url( get_post_thumbnail_id( $post->ID ) );


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.  This PR adds a new function, `get_location_latlng_str()`, which returns a lat+lng string suitable for use in google map query params, and uses that function everywhere a google map embed/link is necessary instead of repeating lat+lng display logic in multiple places.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #220.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested locally.  Can't find any existing problematic locations in Dev to test against, and can't set up a test post without pushing a code update to the Location CPT plugin.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
