### PR TITLE
Prevent Lazy Loader plugin from lazyload-ifying REST API contents

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -583,3 +583,24 @@ function yoast_sitemap_empty_terms( $hide_empty, $taxonomies ) {
 }
 
 add_filter( 'wpseo_sitemap_exclude_empty_terms', 'yoast_sitemap_empty_terms', 10, 2 );
+
+
+/**
+ * Prevent the Lazy Loader plugin from modifying contents of REST API feeds.
+ *
+ * @since v3.3.9
+ * @author Jo Dickson
+ */
+function disable_lazyload_in_rest() {
+	global $lazy_loader;
+
+	if (
+		isset( $lazy_loader )
+		&& $lazy_loader instanceof FlorianBrinkmann\LazyLoadResponsiveImages\Plugin
+		&& is_rest()
+	) {
+		remove_filter( 'the_content', array( $lazy_loader, 'filter_markup' ), 10001 );
+	}
+}
+
+add_action( 'init', 'disable_lazyload_in_rest' );

--- a/includes/config.php
+++ b/includes/config.php
@@ -597,10 +597,9 @@ function disable_lazyload_in_rest() {
 	if (
 		isset( $lazy_loader )
 		&& $lazy_loader instanceof FlorianBrinkmann\LazyLoadResponsiveImages\Plugin
-		&& is_rest()
 	) {
 		remove_filter( 'the_content', array( $lazy_loader, 'filter_markup' ), 10001 );
 	}
 }
 
-add_action( 'init', 'disable_lazyload_in_rest' );
+add_action( 'rest_api_init', 'disable_lazyload_in_rest' );

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -93,3 +93,32 @@ function get_attachment_src_by_size( $id, $size ) {
 	}
 	return $attachment;
 }
+
+
+
+if ( ! function_exists( 'is_rest' ) ) {
+	/**
+	 * Checks if the current request is a WP REST API request.
+	 *
+	 * @return boolean
+	 * @see https://gist.github.com/matzeeable/dfd82239f48c2fedef25141e48c8dc30
+	 */
+	function is_rest() {
+		if (
+			( defined( 'REST_REQUEST' ) && REST_REQUEST )
+			|| (
+				isset( $_GET['rest_route'] )
+				&& strpos( trim( $_GET['rest_route'], '\\/' ), rest_get_url_prefix() , 0 ) === 0
+			)
+		) {
+			return true;
+		}
+
+		global $wp_rewrite;
+		if ( $wp_rewrite === null ) $wp_rewrite = new WP_Rewrite();
+
+		$rest_url = wp_parse_url( trailingslashit( rest_url() ) );
+		$current_url = wp_parse_url( add_query_arg( array() ) );
+		return strpos( $current_url['path'], $rest_url['path'], 0 ) === 0;
+	}
+}

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -93,32 +93,3 @@ function get_attachment_src_by_size( $id, $size ) {
 	}
 	return $attachment;
 }
-
-
-
-if ( ! function_exists( 'is_rest' ) ) {
-	/**
-	 * Checks if the current request is a WP REST API request.
-	 *
-	 * @return boolean
-	 * @see https://gist.github.com/matzeeable/dfd82239f48c2fedef25141e48c8dc30
-	 */
-	function is_rest() {
-		if (
-			( defined( 'REST_REQUEST' ) && REST_REQUEST )
-			|| (
-				isset( $_GET['rest_route'] )
-				&& strpos( trim( $_GET['rest_route'], '\\/' ), rest_get_url_prefix() , 0 ) === 0
-			)
-		) {
-			return true;
-		}
-
-		global $wp_rewrite;
-		if ( $wp_rewrite === null ) $wp_rewrite = new WP_Rewrite();
-
-		$rest_url = wp_parse_url( trailingslashit( rest_url() ) );
-		$current_url = wp_parse_url( add_query_arg( array() ) );
-		return strpos( $current_url['path'], $rest_url['path'], 0 ) === 0;
-	}
-}


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Lazy Loader plugin was being a little too effective and filtering contents displayed in our REST API feeds, subsequently breaking other sites that utilize those feeds and don't have the lazysizes js library loaded.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev and QA.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
