### PR TITLE
Only display phonebook results marked as active in the search service

### DIFF
--- a/includes/phonebook-functions.php
+++ b/includes/phonebook-functions.php
@@ -18,7 +18,8 @@ function get_phonebook_results( $query ) {
 	$url = get_theme_mod_or_default( 'search_service_url' );
 
 	$params = array(
-		'search' => $query
+		'search' => $query,
+		'active' => 'True'
 	);
 
 	$response = wp_remote_get( $url . '?' . http_build_query( $params ) );


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Supports the ability in the Django Search Service to mark teledata results as active/inactive (as of v1.5.2)

Resolves #229 

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
