### PR TITLE
Imported degree deadline data; read-only repeater fields

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1060,9 +1060,9 @@
                 "button_label": "",
                 "sub_fields": [
                     {
-                        "key": "field_5eb45884db2a1",
-                        "label": "Admission Term",
-                        "name": "admission_term",
+                        "key": "field_5eb458b1db2a2",
+                        "label": "Deadline Type",
+                        "name": "deadline_type",
                         "type": "read_only",
                         "instructions": "",
                         "required": 0,
@@ -1076,9 +1076,9 @@
                         "display_type": "text"
                     },
                     {
-                        "key": "field_5eb458b1db2a2",
-                        "label": "Deadline Type",
-                        "name": "deadline_type",
+                        "key": "field_5eb45884db2a1",
+                        "label": "Admission Term",
+                        "name": "admission_term",
                         "type": "read_only",
                         "instructions": "",
                         "required": 0,

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -589,7 +589,7 @@
         "fields": [
             {
                 "key": "field_5ae0c4dcee248",
-                "label": "Custom Degree Data",
+                "label": "Custom Data",
                 "name": "",
                 "type": "tab",
                 "instructions": "",
@@ -642,7 +642,7 @@
             },
             {
                 "key": "field_5adf83192113d",
-                "label": "Imported Degree Data",
+                "label": "Degree Data",
                 "name": "",
                 "type": "tab",
                 "instructions": "",
@@ -1014,6 +1014,144 @@
                 "name": "degree_prj_openings",
                 "type": "read_only",
                 "instructions": "The projected number of openings for graduates with this degree within the report's timeframe.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "copy_to_clipboard": 0,
+                "display_type": "text"
+            },
+            {
+                "key": "field_5eb457b4db29f",
+                "label": "Application Deadlines and Info",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_5eb45823db2a0",
+                "label": "Deadlines",
+                "name": "degree_application_deadlines",
+                "type": "repeater",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "repeater-field-readonly",
+                    "id": ""
+                },
+                "collapsed": "",
+                "min": 0,
+                "max": 0,
+                "layout": "table",
+                "button_label": "",
+                "sub_fields": [
+                    {
+                        "key": "field_5eb45884db2a1",
+                        "label": "Admission Term",
+                        "name": "admission_term",
+                        "type": "read_only",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "copy_to_clipboard": 0,
+                        "display_type": "text"
+                    },
+                    {
+                        "key": "field_5eb458b1db2a2",
+                        "label": "Deadline Type",
+                        "name": "deadline_type",
+                        "type": "read_only",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "copy_to_clipboard": 0,
+                        "display_type": "text"
+                    },
+                    {
+                        "key": "field_5eb458badb2a3",
+                        "label": "Deadline",
+                        "name": "deadline",
+                        "type": "read_only",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "copy_to_clipboard": 0,
+                        "display_type": "text"
+                    }
+                ]
+            },
+            {
+                "key": "field_5eb45904db2a4",
+                "label": "Application Requirements",
+                "name": "degree_application_requirements",
+                "type": "repeater",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "repeater-field-readonly",
+                    "id": ""
+                },
+                "collapsed": "",
+                "min": 0,
+                "max": 0,
+                "layout": "table",
+                "button_label": "",
+                "sub_fields": [
+                    {
+                        "key": "field_5eb4591fdb2a5",
+                        "label": "Requirement",
+                        "name": "requirement",
+                        "type": "read_only",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "copy_to_clipboard": 0,
+                        "display_type": "text"
+                    }
+                ]
+            },
+            {
+                "key": "field_5eb45938db2a6",
+                "label": "Deadline Details",
+                "name": "degree_deadline_details",
+                "type": "read_only",
+                "instructions": "",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {

--- a/includes/config.php
+++ b/includes/config.php
@@ -695,7 +695,7 @@ function read_only_repeater_fields() {
 					.find('.acf-actions')
 						.remove()
 						.end()
-					.find('.acf-row-handle:last-child')
+					.find('.acf-row-handle')
 						.remove()
 			});
 

--- a/includes/config.php
+++ b/includes/config.php
@@ -643,3 +643,68 @@ function disable_lazyload_in_rest() {
 }
 
 add_action( 'rest_api_init', 'disable_lazyload_in_rest' );
+
+
+/**
+ * Disable the post content WYSIWYG editor for degrees
+ * that use the 'modern' degree template
+ *
+ * @since 3.4.0
+ * @author Jo Dickson
+ */
+function modern_degree_hide_editor() {
+	$current_screen = get_current_screen();
+
+	if (
+		$current_screen
+		&& $current_screen->id === 'degree'
+		&& $current_screen->post_type === 'degree'
+	) {
+		$post_id = $_GET['post'];
+		if ( ! $post_id ) return;
+
+		if ( get_page_template_slug( $post_id ) === 'template-degree-modern.php' ) {
+			remove_post_type_support( 'degree', 'editor' );
+		}
+	}
+}
+
+add_action( 'admin_head', 'modern_degree_hide_editor' );
+
+
+/**
+ * Modifies Degree deadline and application requirement
+ * repeater fields to be read-only in the WP admin.
+ *
+ * @since 3.4.1
+ * @author Jo Dickson
+ */
+function read_only_repeater_fields() {
+	ob_start();
+?>
+	<script type="text/javascript">
+	(function($) {
+
+		acf.add_action('ready', function( $el ) {
+
+			var $readonly_fields = $('.repeater-field-readonly');
+			$readonly_fields.each(function() {
+				var $field = $(this);
+
+				$field
+					.find('.acf-actions')
+						.remove()
+						.end()
+					.find('.acf-row-handle:last-child')
+						.remove()
+			});
+
+		});
+
+	})(jQuery);
+	</script>
+<?php
+	echo ob_get_clean();
+}
+
+add_action( 'acf/input/admin_footer', 'read_only_repeater_fields' );

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -511,7 +511,7 @@ function get_degree_course_overview_modern_layout( $degree ) {
 				<?php if( ! empty( $post_meta['degree_pdf'] ) ) : ?>
 					<div class="row">
 						<div class="col-12 text-right">
-							
+
 						<a href="<?php echo $post_meta['degree_pdf']; ?>" rel="nofollow">
 							<?php
 							if( $course_catalog_link_text ) :
@@ -1689,30 +1689,3 @@ function main_site_degree_careers( $post_id, $post_meta ) {
 
 	return ob_get_clean();
 }
-
-
-/**
- * Disable the post content WYSIWYG editor for degrees
- * that use the 'modern' degree template
- *
- * @since 3.4.0
- * @author Jo Dickson
- */
-function modern_degree_hide_editor() {
-	$current_screen = get_current_screen();
-
-	if (
-		$current_screen
-		&& $current_screen->id === 'degree'
-		&& $current_screen->post_type === 'degree'
-	) {
-		$post_id = $_GET['post'];
-		if ( ! $post_id ) return;
-
-		if ( get_page_template_slug( $post_id ) === 'template-degree-modern.php' ) {
-			remove_post_type_support( 'degree', 'editor' );
-		}
-	}
-}
-
-add_action( 'admin_head', 'modern_degree_hide_editor' );

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -1350,8 +1350,9 @@ function mainsite_degree_format_post_data( $meta, $program ) {
 	$meta['page_header_height'] = 'header-media-default';
 	$meta['degree_description'] = get_api_catalog_description( $program );
 
-	$outcomes    = main_site_get_remote_response_json( $program->outcomes );
-	$projections = main_site_get_remote_response_json( $program->projection_totals );
+	$outcomes      = main_site_get_remote_response_json( $program->outcomes );
+	$projections   = main_site_get_remote_response_json( $program->projection_totals );
+	$deadline_data = main_site_get_remote_response_json( $program->application_deadlines );
 
 	$meta['degree_avg_annual_earnings'] = isset( $outcomes->latest->avg_annual_earnings ) ?
 		$outcomes->latest->avg_annual_earnings :
@@ -1396,6 +1397,28 @@ function mainsite_degree_format_post_data( $meta, $program ) {
 	$meta['degree_prj_openings'] = isset( $projections->openings ) ?
 		$projections->openings :
 		null;
+
+	$meta['degree_application_deadlines'] = array();
+	if ( isset( $deadline_data->application_deadlines ) ) {
+		foreach ( $deadline_data->application_deadlines as $deadline ) {
+			$meta['degree_application_deadlines'][] = array(
+				'admission_term' => $deadline->admission_term,
+				'deadline_type'  => $deadline->deadline_type,
+				'deadline'       => $deadline->display
+			);
+		}
+	}
+
+	$meta['degree_application_requirements'] = array();
+	if ( isset( $deadline_data->application_requirements ) ) {
+		foreach ( $deadline_data->application_requirements as $requirement ) {
+			$meta['degree_application_requirements'][] = array(
+				'requirement' => $requirement
+			);
+		}
+	}
+
+	$meta['degree_deadline_details'] = $deadline_data->application_deadline_details ?? null;
 
 	return $meta;
 }


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Read-only ACF fields:
- Added the ability to define read-only ACF repeater fields.  The parent repeater field should have the `repeater-field-readonly` CSS class applied to it, and all subfields should be set as read-only fields (via the ACF Read-Only plugin).  The `repeater-field-readonly` CSS class will be used to disable add/remove row and re-ordering toggles in the admin via inline JS (see `read_only_repeater_fields()`).

Deadline data:
- Added new read-only repeater fields for storing imported degree deadlines and application requirements, as well as a read-only text field for deadline details (we don't currently have any deadline detail data however--I may remove this field in a future PR.  See #https://github.com/UCF/Search-Service-Django/issues/165)
- Added degree import override to import degree deadline data.

Other:
- Moved `modern_degree_hide_editor()` from ` includes/degree-functions.php` to `includes/config.php`. 

These changes are dependent on changes incoming in Search-Service-Django v1.6.0.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of a push to begin utilizing external program deadline information.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
