### PR TITLE
Graduate Slate GUIDs

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -665,7 +665,7 @@
                 "required": 1,
                 "conditional_logic": 0,
                 "wrapper": {
-                    "width": "50",
+                    "width": "30",
                     "class": "",
                     "id": ""
                 },
@@ -681,7 +681,23 @@
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
-                    "width": "50",
+                    "width": "30",
+                    "class": "",
+                    "id": ""
+                },
+                "copy_to_clipboard": 0,
+                "display_type": "text"
+            },
+            {
+                "key": "field_5ed01d99c33fb",
+                "label": "Graduate Slate ID",
+                "name": "graduate_slate_id",
+                "type": "read_only",
+                "instructions": "The GUID of this program in Graduate Studies' Slate instance. (Applies to graduate programs only)",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "40",
                     "class": "",
                     "id": ""
                 },

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -952,6 +952,7 @@ function get_degree_request_info_modal( $degree ) {
 			$plan_sub_plan = get_field( 'degree_plan_code', $degree ) . get_field( 'degree_subplan_code', $degree );
 			$guid = $degrees[$plan_sub_plan];
 		}
+	}
 	if ( ! $guid ) return '';
 
 	$form_div_id  = 'form_bad6c39a-5c60-4895-9128-5785ce014085';

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -511,7 +511,7 @@ function get_degree_course_overview_modern_layout( $degree ) {
 				<?php if( ! empty( $post_meta['degree_pdf'] ) ) : ?>
 					<div class="row">
 						<div class="col-12 text-right">
-							
+
 						<a href="<?php echo $post_meta['degree_pdf']; ?>" rel="nofollow">
 							<?php
 							if( $course_catalog_link_text ) :
@@ -940,16 +940,23 @@ function get_degree_request_info_modal( $degree ) {
 	// (and the rest of this function) will have to be adjusted:
 	if ( ! is_graduate_degree( $degree ) ) return $markup;
 
-	// Retrieve GUID data that map plan+subplan codes to programs
-	// in the RFI form.  Back out early if something fails.
-	$guid_data = file_get_contents( THEME_JS_DIR . '/guid.json' );
-	if ( ! $guid_data ) return '';
+	// Back out early if a GUID isn't assigned to the program.
+	$guid = get_field( 'graduate_slate_id', $degree );
+	if ( ! $guid ) {
+		// Retrieve GUID data that map plan+subplan codes to programs
+		// in the RFI form.  Back out early if something fails.
+		// (This block will be removed in a future release)
+		$guid_data = file_get_contents( THEME_JS_DIR . '/guid.json' );
+		if ( $guid_data ) {
+			$degrees = json_decode( $guid_data, true );
+			$plan_sub_plan = get_field( 'degree_plan_code', $degree ) . get_field( 'degree_subplan_code', $degree );
+			$guid = $degrees[$plan_sub_plan];
+		}
+	if ( ! $guid ) return '';
 
-	$degrees = json_decode( $guid_data, true );
-	$plan_sub_plan = get_field( 'degree_plan_code', $degree ) . get_field( 'degree_subplan_code', $degree );
 	$form_div_id  = 'form_bad6c39a-5c60-4895-9128-5785ce014085';
 	$rfi_form_src = get_degree_request_info_url_graduate( array(
-		'sys:field:pros_program1' => $degrees[$plan_sub_plan],
+		'sys:field:pros_program1' => $guid,
 		'output' => 'embed',
 		'div' => $form_div_id
 	) );
@@ -1349,6 +1356,7 @@ function main_site_get_remote_response_json( $url, $default=null ) {
 function mainsite_degree_format_post_data( $meta, $program ) {
 	$meta['page_header_height'] = 'header-media-default';
 	$meta['degree_description'] = get_api_catalog_description( $program );
+	$meta['graduate_slate_id']  = $program->graduate_slate_id ?? null;
 
 	$outcomes    = main_site_get_remote_response_json( $program->outcomes );
 	$projections = main_site_get_remote_response_json( $program->projection_totals );


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Added meta field and updated import overrides to store graduate Slate IDs from the search service.

Depends on Search Service v1.5.6; specifically, https://github.com/UCF/Search-Service-Django/pull/169.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
First step in removing hard-coded graduate Slate GUIDs from the theme in favor of managing them in the search service.

The last step will happen after this change is tagged, deployed, and a fresh WP degree import is run against the search service running v1.5.6; see #256 

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
