### PR TITLE
Only display published degrees in colleges' top programs lists

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -21,19 +21,24 @@ include_once 'includes/post-list-layouts.php';
 **/
 function display_top_degrees( $term ) {
 	$ret = "";
-	$top_degrees = get_field( 'top_degrees', 'colleges_' . $term->term_id );
-	if( $top_degrees ) :
-		foreach( $top_degrees as $top_degree ) :
-			$ret .= '<li><a href="' . get_permalink( $top_degree->ID ) . '" class="text-inverse nav-link">' . $top_degree->post_title . '</a></li>';
+
+	$top_degrees = get_field( 'top_degrees', $term );
+	if ( $top_degrees ) :
+		foreach ( $top_degrees as $top_degree ) :
+			// Ensure stale degrees are omitted from this list:
+			if ( $top_degree->post_status === 'publish' ):
+				$ret .= '<li><a href="' . get_permalink( $top_degree->ID ) . '" class="text-inverse nav-link">' . $top_degree->post_title . '</a></li>';
+			endif;
 		endforeach;
 	endif;
 
-	$top_degrees_custom = get_field( 'top_degrees_custom', 'colleges_' . $term->term_id );
-	if( $top_degrees_custom ) :
-		foreach( $top_degrees_custom as $top_degree_custom ) :
+	$top_degrees_custom = get_field( 'top_degrees_custom', $term );
+	if ( $top_degrees_custom ) :
+		foreach ( $top_degrees_custom as $top_degree_custom ) :
 			$ret .= '<li><a href="' . $top_degree_custom["top_degree_custom_link"] . '" class="text-inverse nav-link">' . $top_degree_custom["top_degree_custom_text"] . '</a></li>';
 		endforeach;
 	endif;
+
 	return $ret;
 }
 

--- a/includes/config.php
+++ b/includes/config.php
@@ -626,6 +626,26 @@ add_filter( 'wpseo_sitemap_exclude_empty_terms', 'yoast_sitemap_empty_terms', 10
 
 
 /**
+ * Ensures that only published degrees are available to
+ * select from when picking existing degrees for Colleges'
+ * "Top Degrees" lists.
+ *
+ * @since 3.4.2
+ * @author Jo Dickson
+ * @param array $args WP_Query args
+ * @param array $field Array of ACF field settings
+ * @param int $post_id Post ID
+ * @return array Modified query args
+ */
+function college_top_degrees_options( $args, $field, $post_id ) {
+	$args['post_status'] = array( 'publish' );
+	return $args;
+}
+
+add_filter( 'acf/fields/post_object/query/name=top_degrees', 'college_top_degrees_options', 10, 3 );
+
+
+/**
  * Prevent the Lazy Loader plugin from modifying contents of REST API feeds.
  *
  * @since v3.3.9

--- a/taxonomy-colleges.php
+++ b/taxonomy-colleges.php
@@ -14,6 +14,7 @@ $degree_copy = get_field( 'degree_search_copy', 'colleges_' . $term->term_id );
 $degree_search_url = "https://www.ucf.edu/degree-search/#!/college/" . $term->slug . "/";
 $degree_types = get_field( 'degree_types_available', 'colleges_' . $term->term_id );
 $degree_types = map_degree_types( $degree_types );
+$top_degrees = display_top_degrees( $term );
 // CTA
 $cta = get_field( 'college_page_cta_section', 'colleges_' . $term->term_id );
 // News
@@ -88,6 +89,8 @@ $spotlight = get_field( 'college_spotlight', 'colleges_' . $term->term_id );
 						?>
 						</ul>
 					</div>
+
+					<?php if ( $top_degrees ): ?>
 					<div class="col-lg-1 hidden-md-down">
 						<hr class="hidden-xs hidden-sm hr-vertical hr-vertical-white center-block">
 					</div>
@@ -98,10 +101,11 @@ $spotlight = get_field( 'college_spotlight', 'colleges_' . $term->term_id );
 						</a>
 						<div id="top-degree-collapse" class="collapse d-lg-block">
 							<ul class="top-majors-list nav flex-column align-items-start list-unstyled pl-3">
-								<?php echo display_top_degrees( $term ); // located in functions.php ?>
+								<?php echo $top_degrees; // located in functions.php ?>
 							</ul>
 						</div>
 					</div>
+					<?php endif; ?>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Added logic to ensure that only published degrees are shown in top programs lists on college profiles.
- Updated available options in the college admin view for selecting top programs to ensure that draft posts are not selectable.  (Existing set programs that are drafts won't be automatically wiped out, but with the new logic mentioned above in the college profiles template, they won't be displayed on the frontend)
- Updated college profile template to not display the top degrees column and the divider before it if no top degrees are available to display.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes a long-standing issue where stale programs would still display on college profiles with broken links.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
