### PR TITLE
Stale degree redirects

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -572,6 +572,33 @@ add_filter( 'redirect_canonical', 'no_redirect_on_404' );
 
 
 /**
+ * Ensures that deleted/drafted degrees are 302 redirected
+ * to the degree search instead of returning a 404.  Helps
+ * avoid situations with broken links after running a
+ * degree import.
+ *
+ * @since 3.4.3
+ * @author Jo Dickson
+ */
+function stale_degree_redirect() {
+	global $wp_query;
+
+	// is_singular() doesn't return an accurate value
+	// this early, so investigate $wp_query directly instead:
+	if (
+		is_404()
+		&& isset( $wp_query->query['post_type'] )
+		&& $wp_query->query['post_type'] === 'degree'
+	) {
+		wp_redirect( home_url( '/degree-search/' ) );
+		exit();
+	}
+}
+
+add_filter( 'template_redirect', 'stale_degree_redirect' );
+
+
+/**
  * Kill attachment pages, author pages, daily archive pages, search, and feeds.
  *
  * http://betterwp.net/wordpress-tips/disable-some-wordpress-pages/

--- a/includes/config.php
+++ b/includes/config.php
@@ -590,7 +590,7 @@ function stale_degree_redirect() {
 		&& isset( $wp_query->query['post_type'] )
 		&& $wp_query->query['post_type'] === 'degree'
 	) {
-		wp_redirect( home_url( '/degree-search/' ) );
+		wp_redirect( home_url( '/degree-search/' ), 307 );
 		exit();
 	}
 }

--- a/includes/config.php
+++ b/includes/config.php
@@ -572,7 +572,7 @@ add_filter( 'redirect_canonical', 'no_redirect_on_404' );
 
 
 /**
- * Ensures that deleted/drafted degrees are 302 redirected
+ * Ensures that deleted/drafted degrees are 307 redirected
  * to the degree search instead of returning a 404.  Helps
  * avoid situations with broken links after running a
  * degree import.


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Added a redirect to force draft and deleted degrees to 307 redirect to /degree-search/ instead of 404ing.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To reduce broken links and users hitting 404 dead ends after running degree imports or removing old degrees by request.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
