### PR TITLE
Fix 'Start Application' section displaying when $app_steps is NULL

### DIFF
--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -481,10 +481,14 @@ function get_degree_start_application_today_modern_layout( $degree ) {
 	$app_content_col_class = ( $app_image ) ? "col-12 col-lg-7" : "col-12 col-lg-10 offset-lg-1";
 
 	// Return an empty string if any of the Application Steps fields are empty.
-	foreach ( $app_steps as $step_field ) {
-		if ( empty( $step_field ) ) {
-			return '';
+	if ( isset( $app_steps ) ) {
+		foreach ( $app_steps as $step_field ) {
+			if ( empty( $step_field ) ) {
+				return '';
+			}
 		}
+	} else {
+		return '';
 	}
 
 	ob_start();


### PR DESCRIPTION
**Description**
See title.

**Motivation and Context**
If a degree page is already set to use the modern template, by default the $app_steps group array is set to NULL. This fixes an empty section displaying in that scenario.

**How Has This Been Tested?**
Fix viewable in DEV vs. QA

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
