### PR TITLE
Adjustments to modern degree template to add options for 'Parent' programs

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1470,8 +1470,8 @@
         "title": "Degree Fields - Modern Layout",
         "fields": [
             {
-                "key": "field_5e99fb2dbcede",
-                "label": "Program at a Glance",
+                "key": "field_5f8e67c342090",
+                "label": "Page Options",
                 "name": "",
                 "type": "tab",
                 "instructions": "",
@@ -1484,6 +1484,87 @@
                 },
                 "placement": "left",
                 "endpoint": 0
+            },
+            {
+                "key": "field_5f8e67d642091",
+                "label": "Is Parent Program",
+                "name": "degree_is_parent_program",
+                "type": "true_false",
+                "instructions": "Set this to true if this program is a parent program and should be displayed with the parent\/umbrella program layout adjustments.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "",
+                "default_value": 0,
+                "ui": 0,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            },
+            {
+                "key": "field_5f9066b2a8273",
+                "label": "Hide Colleges Grid",
+                "name": "degree_hide_colleges_grid",
+                "type": "true_false",
+                "instructions": "Hides the colleges grid displayed above the footer. Defaults to false.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "",
+                "default_value": 0,
+                "ui": 0,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            },
+            {
+                "key": "field_5e99fb2dbcede",
+                "label": "Program at a Glance",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_5f8e67d642091",
+                            "operator": "!=",
+                            "value": "1"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "left",
+                "endpoint": 0
+            },
+            {
+                "key": "field_5ea0a6bcb0c0d",
+                "label": "Program Length Number",
+                "name": "program_length_number",
+                "type": "text",
+                "instructions": "Add the number to be displayed for the program length.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
             },
             {
                 "key": "field_5e986fb2666dc",
@@ -1508,25 +1589,6 @@
                 "max_height": "",
                 "max_size": "",
                 "mime_types": ""
-            },
-            {
-                "key": "field_5ea0a6bcb0c0d",
-                "label": "Program Length Number",
-                "name": "program_length_number",
-                "type": "text",
-                "instructions": "Add the number to be displayed for the program length.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "default_value": "",
-                "placeholder": "",
-                "prepend": "",
-                "append": "",
-                "maxlength": ""
             },
             {
                 "key": "field_5ea0a6e8b0c0e",
@@ -1655,7 +1717,7 @@
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
-                    "width": "",
+                    "width": "50",
                     "class": "",
                     "id": ""
                 },
@@ -1669,6 +1731,25 @@
                 "max_height": "",
                 "max_size": "",
                 "mime_types": ""
+            },
+            {
+                "key": "field_5f8e76505ded8",
+                "label": "Degree Description Image Circle Class",
+                "name": "modern_description_image_circle_class",
+                "type": "true_false",
+                "instructions": "Set to 'yes' if the description image should have the `rounded-circle` class set.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "50",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "",
+                "default_value": 0,
+                "ui": 1,
+                "ui_on_text": "",
+                "ui_off_text": ""
             },
             {
                 "key": "field_5e99d98c3902e",
@@ -1752,6 +1833,162 @@
                         "maxlength": ""
                     }
                 ]
+            },
+            {
+                "key": "field_5f8e6b2b9506f",
+                "label": "Program Tracks",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_5f8e67d642091",
+                            "operator": "==",
+                            "value": "1"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "left",
+                "endpoint": 0
+            },
+            {
+                "key": "field_5f8e6d2995074",
+                "label": "Program Tracks Heading",
+                "name": "program_tracks_heading",
+                "type": "text",
+                "instructions": "Heading for this program's tracks section.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            },
+            {
+                "key": "field_5f8e6d9895075",
+                "label": "Program Tracks Lead Copy",
+                "name": "program_tracks_lead_copy",
+                "type": "textarea",
+                "instructions": "Introduction text displayed underneath the Program Track Section Headline.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "maxlength": "",
+                "rows": 4,
+                "new_lines": ""
+            },
+            {
+                "key": "field_5f8e6b7e95070",
+                "label": "Program Tracks",
+                "name": "program_tracks",
+                "type": "repeater",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "collapsed": "field_5f8e6c4995071",
+                "min": 1,
+                "max": 0,
+                "layout": "block",
+                "button_label": "Add Track",
+                "sub_fields": [
+                    {
+                        "key": "field_5f8e6c4995071",
+                        "label": "Track Heading",
+                        "name": "track_heading",
+                        "type": "text",
+                        "instructions": "Heading displayed for the track.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    },
+                    {
+                        "key": "field_5f8e6c9195072",
+                        "label": "Track Description",
+                        "name": "track_description",
+                        "type": "textarea",
+                        "instructions": "Short description of the track.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "maxlength": "",
+                        "rows": 4,
+                        "new_lines": ""
+                    },
+                    {
+                        "key": "field_5f905f860ec1f",
+                        "label": "Track URL",
+                        "name": "track_url",
+                        "type": "url",
+                        "instructions": "The URL of the track's degree page.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": ""
+                    }
+                ]
+            },
+            {
+                "key": "field_5f8e6de495076",
+                "label": "Program Tracks Custom Content",
+                "name": "program_tracks_custom_content",
+                "type": "wysiwyg",
+                "instructions": "Custom content displayed at the end of the Program Track section, underneath the individual program track cards.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "tabs": "all",
+                "toolbar": "full",
+                "media_upload": 0,
+                "delay": 0
             },
             {
                 "key": "field_5e99f82f12a13",
@@ -2122,7 +2359,7 @@
                 "collapsed": "",
                 "min": 0,
                 "max": 0,
-                "layout": "row",
+                "layout": "block",
                 "button_label": "",
                 "sub_fields": [
                     {
@@ -2134,7 +2371,7 @@
                         "required": 0,
                         "conditional_logic": 0,
                         "wrapper": {
-                            "width": "",
+                            "width": "50",
                             "class": "",
                             "id": ""
                         },
@@ -2148,6 +2385,25 @@
                         "max_height": "",
                         "max_size": "",
                         "mime_types": ""
+                    },
+                    {
+                        "key": "field_5f9062fbe9e36",
+                        "label": "Image Circle Class",
+                        "name": "degree_quote_image_circle_class",
+                        "type": "true_false",
+                        "instructions": "Set to 'yes' if the quote image should have the `rounded-circle` class set.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "50",
+                            "class": "",
+                            "id": ""
+                        },
+                        "message": "",
+                        "default_value": 0,
+                        "ui": 1,
+                        "ui_on_text": "",
+                        "ui_off_text": ""
                     },
                     {
                         "key": "field_5e9f0ddea2389",
@@ -2601,6 +2857,147 @@
                 "multiple": 0,
                 "return_format": "object",
                 "ui": 1
+            },
+            {
+                "key": "field_5f8e71e6b48b3",
+                "label": "Callout",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_5f8e67d642091",
+                            "operator": "==",
+                            "value": "1"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "left",
+                "endpoint": 0
+            },
+            {
+                "key": "field_5f8e71e9b48b4",
+                "label": "Callout Heading",
+                "name": "degree_callout_heading",
+                "type": "text",
+                "instructions": "The heading to be displayed in the callout section.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            },
+            {
+                "key": "field_5f8e71f3b48b5",
+                "label": "Callout Copy",
+                "name": "degree_callout_copy",
+                "type": "textarea",
+                "instructions": "Copy displayed under the callout heading.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "maxlength": "",
+                "rows": 3,
+                "new_lines": ""
+            },
+            {
+                "key": "field_5f8e71f5b48b6",
+                "label": "Callout Button",
+                "name": "degree_callout_button",
+                "type": "group",
+                "instructions": "Button displayed under the callout copy.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "layout": "block",
+                "sub_fields": [
+                    {
+                        "key": "field_5f8e71f5b48b7",
+                        "label": "Button Text",
+                        "name": "button_text",
+                        "type": "text",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    },
+                    {
+                        "key": "field_5f8e71f5b48b8",
+                        "label": "Button Link",
+                        "name": "button_link",
+                        "type": "text",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    }
+                ]
+            },
+            {
+                "key": "field_5f8e71f9b48b9",
+                "label": "Callout Image",
+                "name": "degree_callout_image",
+                "type": "image",
+                "instructions": "Image to be displayed to the right of the callout heading, copy and button. The image will be hidden in the xs, sm and md breakpoints.\r\n<br><br>\r\nThe image should be a square 300px by 300px JPG with the focus of the image in the center. The circular crop is handled with CSS.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "return_format": "url",
+                "preview_size": "medium",
+                "library": "all",
+                "min_width": "",
+                "min_height": "",
+                "min_size": "",
+                "max_width": 300,
+                "max_height": 300,
+                "max_size": "",
+                "mime_types": "jpg"
             }
         ],
         "location": [

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -1388,6 +1388,55 @@ function ucf_tuition_fees_degree_modern_layout( $resident, $nonresident ) {
 
 
 /**
+  * Returns HTML for the modern degree callout section.
+  *
+  * @since 3.7.0
+  * @author Cadie Stockman
+  * @param object $degree WP_Post object representing a degree
+  * @return string HTML markup
+  */
+  function get_degree_callout_modern_layout( $degree ) {
+	$callout_heading = get_field( 'degree_callout_heading', $degree );
+	$callout_copy    = get_field( 'degree_callout_copy', $degree );
+	$callout_button  = get_field( 'degree_callout_button', $degree );
+	$callout_image   = get_field( 'degree_callout_image', $degree );
+
+	// Set content column classes based on if an image for the section is set.
+	$callout_content_col_class = ( $callout_image ) ? "col-12 col-lg-8" : "col-12";
+
+	// Return an empty string if some of the callout fields are empty.
+	if ( empty( $callout_heading ) || empty( $callout_copy ) ) return '';
+
+	foreach ( $callout_button as $button_field ) {
+		if ( empty( $button_field ) ) {
+			return '';
+		}
+	}
+
+	ob_start();
+	?>
+		<div class="jumbotron bg-secondary mb-0 py-lg-5">
+			<div class="container">
+				<div class="row">
+					<div class="<?php echo $callout_content_col_class; ?> d-flex flex-column justify-content-center align-items-start">
+						<h2 class="mb-3 mb-lg-4"><?php echo $callout_heading; ?></h2>
+						<p class="degree-online-copy mb-4 pb-lg-2"><?php echo $callout_copy; ?></p>
+						<a class="btn btn-primary" href="<?php echo $callout_button['button_link']; ?>"><?php echo $callout_button['button_text']; ?></a>
+					</div>
+					<?php if ( $callout_image ) : ?>
+					<div class="col-lg-4 hidden-md-down d-flex align-items-center justify-content-end">
+						<img src="<?php echo $callout_image; ?>" class="img-fluid rounded-circle" alt="" aria-hidden="true">
+					</div>
+					<?php endif; ?>
+				</div>
+			</div>
+		</div>
+	<?php
+	return ob_get_clean();
+}
+
+
+/**
  * Returns the markup for breadcrumbs for a single degree profile.
  *
  * @author Jo Dickson

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -632,9 +632,10 @@ function get_degree_course_overview_modern_layout( $degree ) {
  * @return string HTML markup
  */
 function get_degree_quotes_modern_layout( $degree ) {
-	$course_overview = get_field( 'course_overview', $degree );
+	$course_overview   = get_field( 'course_overview', $degree );
+	$is_parent_program = get_field( 'degree_is_parent_program', $degree );
 
-	if ( empty( $course_overview ) ) return '';
+	if ( ! $is_parent_program && empty( $course_overview ) ) return '';
 
 	ob_start();
 

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -314,6 +314,7 @@ function get_degree_description_modern_layout( $degree ) {
 	$modern_description_copy = get_field( 'modern_description_copy', $degree );
 	$modern_description_image = get_field( 'modern_description_image', $degree );
 	$modern_description_image_alt = get_field( 'modern_description_image_alt', $degree );
+	$modern_description_image_circle_class = get_field( 'modern_description_image_circle_class' ) ? 'rounded-circle' : '';
 
 	if( empty( $modern_description_heading ) && empty( $modern_description_copy ) ) return '';
 
@@ -347,7 +348,7 @@ function get_degree_description_modern_layout( $degree ) {
 				<div class="col-lg-6 pl-lg-5 mt-5 mt-lg-0">
 					<?php if ( $modern_description_image ) : ?>
 						<div class="px-5 px-lg-0 text-center">
-							<img src="<?php echo $modern_description_image; ?>" class="img-fluid mb-5" alt="<?php echo $modern_description_image_alt; ?>">
+							<img src="<?php echo $modern_description_image; ?>" class="img-fluid mb-5 <?php echo $modern_description_image_circle_class; ?>" alt="<?php echo $modern_description_image_alt; ?>">
 						</div>
 					<?php endif; ?>
 
@@ -641,11 +642,13 @@ function get_degree_quotes_modern_layout( $degree ) {
 		<section>
 			<div class="jumbotron jumbotron-fluid bg-faded mb-0">
 				<div class="container">
-					<?php while ( have_rows( 'degree_quotes', $degree ) ) : the_row(); ?>
+					<?php while ( have_rows( 'degree_quotes', $degree ) ) : the_row();
+						$circle_class = ( get_sub_field( 'degree_quote_image_circle_class' ) ) ? 'rounded-circle' : '';
+					?>
 						<div class="row">
 							<?php if( get_sub_field( 'degree_quote_image' ) ) : ?>
 								<div class="col-lg-3 text-center text-lg-right align-self-center">
-									<img src="<?php the_sub_field( 'degree_quote_image' ); ?>" class="img-fluid"
+									<img src="<?php the_sub_field( 'degree_quote_image' ); ?>" class="img-fluid <?php echo $circle_class; ?>"
 										alt="<?php the_sub_field( 'degree_quote_image_alt' ); ?>">
 								</div>
 							<?php endif; ?>

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -321,7 +321,7 @@ function get_degree_description_modern_layout( $degree ) {
 	ob_start();
 ?>
 	<section aria-label="Program description and highlights">
-		<div class="container py-lg-3 my-lg-5">
+		<div class="container py-lg-3 mt-4 my-lg-5">
 			<div class="row">
 				<div class="col">
 					<?php if( $modern_description_heading ) : ?>

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -113,8 +113,18 @@
  *
  */
 function get_degree_content_modern_layout( $degree ) {
-	echo get_degree_info_modern_layout( $degree );
+	$is_parent_program = get_field( 'degree_is_parent_program', $degree );
+
+	if ( ! $is_parent_program ) {
+		echo get_degree_info_modern_layout( $degree );
+	}
+
 	echo get_degree_description_modern_layout( $degree );
+
+	if ( $is_parent_program ) {
+		echo get_degree_tracks_modern_layout( $degree );
+	}
+
 	echo get_degree_application_deadline_modern_layout( $degree );
 	echo get_degree_start_application_today_modern_layout( $degree );
 	echo get_degree_course_overview_modern_layout( $degree );
@@ -123,6 +133,10 @@ function get_degree_content_modern_layout( $degree ) {
 	echo get_degree_admission_requirements_modern_layout( $degree );
 	echo get_degree_ucf_online_modern_layout( $degree );
 	echo get_degree_news_spotlight_modern_layout( $degree );
+
+	if ( $is_parent_program ) {
+		echo get_degree_callout_modern_layout( $degree );
+	}
 }
 
 

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -377,6 +377,67 @@ function get_degree_description_modern_layout( $degree ) {
 
 
 /**
+ * Returns HTML for the tracks/subplan section.
+ *
+ * @since 3.7.0
+ * @author Cadie Stockman
+ * @param object $degree WP_Post object representing a degree
+ * @return string HTML markup
+ */
+function get_degree_tracks_modern_layout( $degree ) {
+	$tracks_heading        = get_field( 'program_tracks_heading', $degree );
+	$tracks_lead           = get_field( 'program_tracks_lead_copy', $degree );
+	$tracks_custom_content = get_field( 'program_tracks_custom_content' );
+
+	if ( empty( $tracks_heading ) && empty( $tracks_lead ) ) return '';
+
+	ob_start();
+	?>
+		<section id="program-tracks" aria-label="<?php echo $degree->post_title; ?> Tracks" class="bg-faded">
+			<div class="jumbotron mb-0 py-5">
+				<div class="container">
+					<div class="row text-center mb-4">
+						<div class="col-12">
+							<h2 class="h1 mb-3"><?php echo $tracks_heading; ?></h2>
+							<p class="lead"><?php echo $tracks_lead; ?></p>
+						</div>
+					</div>
+					<?php if ( have_rows( 'program_tracks', $degree ) ) : ?>
+					<div class="row">
+						<?php while ( have_rows( 'program_tracks', $degree ) ) : the_row(); ?>
+							<div class="col-12 mb-4">
+								<a href="<?php the_sub_field( 'track_url' ); ?>" class="d-block hover-parent text-decoration-none text-secondary h-100">
+									<div class="card border-0 card-secondary">
+										<h3 class="card-header h5 bg-primary d-flex align-items-center justify-content-between">
+											<?php the_sub_field( 'track_heading' ); ?>
+											<span class="fa fa-chevron-right hover-child-show fade" aria-hidden="true"></span>
+										</h3>
+										<div class="card-block">
+											<div class="card-text">
+											<?php the_sub_field( 'track_description' ); ?>
+											</div>
+										</div>
+									</div>
+								</a>
+							</div>
+						<?php endwhile; ?>
+					</div>
+					<?php endif; ?>
+
+					<?php if ( $tracks_custom_content ) : ?>
+					<div class="row">
+						<?php echo $tracks_custom_content; ?>
+					</div>
+					<?php endif; ?>
+				</div>
+			</div>
+		</section>
+	<?php
+	return ob_get_clean();
+}
+
+
+/**
  * Returns HTML for the application deadline section.
  *
  * @since 3.4.0

--- a/template-degree-modern.php
+++ b/template-degree-modern.php
@@ -30,7 +30,11 @@ if ( isset( $post_meta['degree_full_width_content_bottom'] ) && ! empty( $post_m
 }
 ?>
 
-<?php echo get_colleges_grid( $college ); ?>
+<?php
+if ( ! get_field( 'degree_hide_colleges_grid', $post ) ) {
+	echo get_colleges_grid( $college );
+}
+?>
 
 <?php
 if ( is_graduate_degree( $post ) ) {


### PR DESCRIPTION
**Description**
Adds fields and functionality to display new sections based on whether the degree program is a 'parent program'. 

**Motivation and Context**
These changes and additions to the modern degree template are based on the requirements needed to create/adjust the UCF MBA umbrella program page, but could be expanded upon in the future for other parent programs.

Notable changes are:
- Hides 'Program at a Glance' section if the 'parent program' field is true
- Adds fields and logic for displaying a program tracks section if parent page
- Adds fields and logic for display a callout at the bottom of the page if parent page
- Display quotes section if it's a parent page (this is hidden if the $course_overview content is empty)
- Adds option for hiding the colleges grid

Also added fields and logic for whether or not to add the 'rounded-circle' class to the description image and quotes image so that those images don't have to be cropped into circles/exported as either png or jpg with a colored background to match.

**How Has This Been Tested?**
Template changes viewable in dev.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
