### PR TITLE
Add Custom Degree Template

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1235,10 +1235,10 @@
         "fields": [
             {
                 "key": "field_5f93258d2ddac",
-                "label": "Display Request Info Button\/Modal in Header",
-                "name": "degree_custom_rfi_header",
+                "label": "Enable Request Info Button\/Modal",
+                "name": "degree_custom_enable_rfi",
                 "type": "true_false",
-                "instructions": "Determines if the 'Request Information' button is displayed in the header, along with adding the Slate RFI form modal code to the page. <i>Note: This feature is currently only available for <strong>graduate<\/strong> programs that have Slate GUIDs imported.<\/i><br><br>\r\nIf you'd like to display a button that opens the RFI modal somewhere else on the page, you can create add a [modal-toggle] shortcode with the target set to '#requestInfoModal'. <br>Example: <code>[modal-toggle class=\"btn btn-complementary\" target=\"#requestInfoModal\"]Button Copy Here[\/modal-toggle]<\/code>",
+                "instructions": "If enabled, the 'Request Information' modal and button will be included on the page. <i>Note: This feature is currently only available for <strong>graduate<\/strong> programs that have Slate GUIDs imported.<\/i><br><br>\r\nIf enabled and you'd like to display a button that opens the RFI modal somewhere else on the page, you can create add a [modal-toggle] shortcode with the target set to '#requestInfoModal'. <br>Example: <code>[modal-toggle class=\"btn btn-complementary\" target=\"#requestInfoModal\"]Button Copy Here[\/modal-toggle]<\/code>",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1230,6 +1230,72 @@
         "description": ""
     },
     {
+        "key": "group_5f932570666c4",
+        "title": "Degree Fields - Custom Template",
+        "fields": [
+            {
+                "key": "field_5f93258d2ddac",
+                "label": "Display Request Info Button\/Modal in Header",
+                "name": "degree_custom_rfi_header",
+                "type": "true_false",
+                "instructions": "Determines if the 'Request Information' button is displayed in the header, along with adding the Slate RFI form modal code to the page. <i>Note: This feature is currently only available for <strong>graduate<\/strong> programs that have Slate GUIDs imported.<\/i><br><br>\r\nIf you'd like to display a button that opens the RFI modal somewhere else on the page, you can create add a [modal-toggle] shortcode with the target set to '#requestInfoModal'. <br>Example: <code>[modal-toggle class=\"btn btn-complementary\" target=\"#requestInfoModal\"]Button Copy Here[\/modal-toggle]<\/code>",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "",
+                "default_value": 0,
+                "ui": 1,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            },
+            {
+                "key": "field_5f9328062ddad",
+                "label": "Hide Colleges Grid",
+                "name": "degree_custom_hide_colleges_grid",
+                "type": "true_false",
+                "instructions": "Determines if the colleges grid is hidden from displaying above the footer.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "",
+                "default_value": 0,
+                "ui": 1,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "degree"
+                },
+                {
+                    "param": "post_template",
+                    "operator": "==",
+                    "value": "template-degree-custom.php"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": true,
+        "description": ""
+    },
+    {
         "key": "group_5df8fb174faec",
         "title": "Degree Fields - Default Template",
         "fields": [

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -758,7 +758,7 @@ function get_degree_admission_requirements_modern_layout( $degree ) {
 							$degree,
 							'btn btn-primary hidden-md-down',
 							'',
-							'Request Information',
+							'Request Information'
 						);
 						?>
 					</div>

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -144,7 +144,7 @@ function get_header_content_degree( $markup, $obj ) {
 		$subtitle_elem                = ( $h1 === 'subtitle' ) ? 'h1' : 'span';
 		$degree_template              = get_page_template_slug( $obj );
 		$show_degree_request_info_btn = false;
-		$custom_template_show_rfi     = ( $degree_template === 'template-degree-custom.php' ) ? get_field( 'degree_custom_rfi_header', $obj ) : false;
+		$custom_template_show_rfi     = ( $degree_template === 'template-degree-custom.php' ) ? get_field( 'degree_custom_enable_rfi', $obj ) : false;
 		$header_content_col_classes   = 'header-degree-content-col col-sm-auto d-sm-flex align-items-sm-center';
 
 		if ( $degree_template === 'template-degree-modern.php' || $custom_template_show_rfi ) {

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -144,9 +144,10 @@ function get_header_content_degree( $markup, $obj ) {
 		$subtitle_elem                = ( $h1 === 'subtitle' ) ? 'h1' : 'span';
 		$degree_template              = get_page_template_slug( $obj );
 		$show_degree_request_info_btn = false;
+		$custom_template_show_rfi     = ( $degree_template === 'template-degree-custom.php' ) ? get_field( 'degree_custom_rfi_header', $obj ) : false;
 		$header_content_col_classes   = 'header-degree-content-col col-sm-auto d-sm-flex align-items-sm-center';
 
-		if ( $degree_template === 'template-degree-modern.php' ) {
+		if ( $degree_template === 'template-degree-modern.php' || $custom_template_show_rfi ) {
 			$header_content_col_classes .= ' ml-sm-auto';
 			$show_degree_request_info_btn = true;
 		}

--- a/template-degree-custom.php
+++ b/template-degree-custom.php
@@ -27,7 +27,7 @@ if ( ! $hide_colleges_grid ) {
 ?>
 
 <?php
-if ( is_graduate_degree( $post ) ) {
+if ( $enable_rfi_modal ) {
 	echo get_degree_request_info_modal( $post );
 }
 ?>

--- a/template-degree-custom.php
+++ b/template-degree-custom.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Template Name: Degree Custom
+ * Template Post Type: degree
+ */
+?>
+
+<?php get_header(); the_post(); ?>
+<?php
+	$raw_postmeta      = get_post_meta( $post->ID );
+	$post_meta         = format_raw_postmeta( $raw_postmeta );
+	$program_type      = get_degree_program_type( $post );
+	$colleges          = wp_get_post_terms( $post->ID, 'colleges' );
+	$college           = is_array( $colleges ) ? $colleges[0] : null;
+	$breadcrumbs       = get_degree_breadcrumb_markup( $post->ID );
+	$hide_colleges_grid = get_field( 'degree_custom_hide_colleges_grid', $post );
+?>
+
+<?php the_content(); ?>
+
+<div class="container mt-4 mb-4 mb-sm-5 pb-md-3">
+	<?php echo $breadcrumbs; ?>
+</div>
+
+<?php
+if ( ! $hide_colleges_grid ) {
+	echo get_colleges_grid( $college );
+}
+?>
+
+<?php
+if ( is_graduate_degree( $post ) ) {
+	echo get_degree_request_info_modal( $post );
+}
+?>
+
+<?php get_footer(); ?>

--- a/template-degree-custom.php
+++ b/template-degree-custom.php
@@ -14,6 +14,7 @@
 	$college           = is_array( $colleges ) ? $colleges[0] : null;
 	$breadcrumbs       = get_degree_breadcrumb_markup( $post->ID );
 	$hide_colleges_grid = get_field( 'degree_custom_hide_colleges_grid', $post );
+	$enable_rfi_modal   = get_field( 'degree_custom_enable_rfi', $post );
 ?>
 
 <?php the_content(); ?>

--- a/template-degree-custom.php
+++ b/template-degree-custom.php
@@ -7,12 +7,9 @@
 
 <?php get_header(); the_post(); ?>
 <?php
-	$raw_postmeta      = get_post_meta( $post->ID );
-	$post_meta         = format_raw_postmeta( $raw_postmeta );
-	$program_type      = get_degree_program_type( $post );
-	$colleges          = wp_get_post_terms( $post->ID, 'colleges' );
-	$college           = is_array( $colleges ) ? $colleges[0] : null;
-	$breadcrumbs       = get_degree_breadcrumb_markup( $post->ID );
+	$colleges           = wp_get_post_terms( $post->ID, 'colleges' );
+	$college            = is_array( $colleges ) ? $colleges[0] : null;
+	$breadcrumbs        = get_degree_breadcrumb_markup( $post->ID );
 	$hide_colleges_grid = get_field( 'degree_custom_hide_colleges_grid', $post );
 	$enable_rfi_modal   = get_field( 'degree_custom_enable_rfi', $post );
 ?>


### PR DESCRIPTION
**Description**
Adds the custom degree template and ACF fields that allow the RFI form to be displayed and the colleges grid hidden.

Also added in is a bugfix in the `get_degree_admission_requirements_modern_layout` function, removing an extra comma from the 'get_degree_request_info_button' call.

**Motivation and Context**
Needed for our super special snowflake degree pages that don't follow the norm.

**How Has This Been Tested?**
Changes viewable in DEV.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
