### PR TITLE
Program at a Glance - Fallback badges; support for up to 2 degree badges

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -642,11 +642,11 @@
                 "endpoint": 0
             },
             {
-                "key": "field_5e986fb2666dc",
-                "label": "Program Length Image",
-                "name": "program_length_image",
-                "type": "image",
-                "instructions": "Add image to be displayed for the program length.",
+                "key": "field_5f9adda85c2cc",
+                "label": "Program Length",
+                "name": "program_length",
+                "type": "group",
+                "instructions": "",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
@@ -654,23 +654,78 @@
                     "class": "",
                     "id": ""
                 },
-                "return_format": "url",
-                "preview_size": "thumbnail",
-                "library": "all",
-                "min_width": "",
-                "min_height": "",
-                "min_size": "",
-                "max_width": "",
-                "max_height": "",
-                "max_size": "",
-                "mime_types": ""
+                "layout": "block",
+                "sub_fields": [
+                    {
+                        "key": "field_5f9addc95c2cd",
+                        "label": "Image",
+                        "name": "image",
+                        "type": "image",
+                        "instructions": "An icon to supplement the program's duration.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "30",
+                            "class": "",
+                            "id": ""
+                        },
+                        "return_format": "url",
+                        "preview_size": "thumbnail",
+                        "library": "all",
+                        "min_width": "",
+                        "min_height": "",
+                        "min_size": "",
+                        "max_width": "",
+                        "max_height": "",
+                        "max_size": "",
+                        "mime_types": ""
+                    },
+                    {
+                        "key": "field_5f9addf15c2ce",
+                        "label": "Number",
+                        "name": "number",
+                        "type": "text",
+                        "instructions": "The actual program length value, e.g. \"30\", \"12-24\"",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "30",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    },
+                    {
+                        "key": "field_5f9ade145c2cf",
+                        "label": "Text",
+                        "name": "text",
+                        "type": "text",
+                        "instructions": "Units of measure, and\/or supplementary info about the program length.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "40",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    }
+                ]
             },
             {
-                "key": "field_5ea0a6bcb0c0d",
-                "label": "Program Length Number",
-                "name": "program_length_number",
-                "type": "text",
-                "instructions": "Add the number to be displayed for the program length.",
+                "key": "field_5f9ae0f0c8e71",
+                "label": "Badges\/Promotional Graphics",
+                "name": "",
+                "type": "message",
+                "instructions": "",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
@@ -678,73 +733,129 @@
                     "class": "",
                     "id": ""
                 },
-                "default_value": "",
-                "placeholder": "",
-                "prepend": "",
-                "append": "",
-                "maxlength": ""
+                "message": "<em>Note: if no badge\/promo graphics are set below, fallback badge(s) defined in the Customizer will be displayed on this degree's profile instead.<\/em>",
+                "new_lines": "wpautop",
+                "esc_html": 0
             },
             {
-                "key": "field_5ea0a6e8b0c0e",
-                "label": "Program Length Text",
-                "name": "program_length_text",
-                "type": "text",
-                "instructions": "Add the text to be displayed under the number for the program length.",
+                "key": "field_5f9ad88cd8a1b",
+                "label": "Badge\/Promo 1",
+                "name": "promo",
+                "type": "group",
+                "instructions": "",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
-                    "width": "",
+                    "width": "50",
                     "class": "",
                     "id": ""
                 },
-                "default_value": "",
-                "placeholder": "",
-                "prepend": "",
-                "append": "",
-                "maxlength": ""
+                "layout": "block",
+                "sub_fields": [
+                    {
+                        "key": "field_5e94d0629bc99",
+                        "label": "Image",
+                        "name": "image",
+                        "type": "image",
+                        "instructions": "A badge, trust symbol, or other promotional graphic relevant to this degree.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "return_format": "url",
+                        "preview_size": "medium",
+                        "library": "all",
+                        "min_width": "",
+                        "min_height": "",
+                        "min_size": "",
+                        "max_width": "",
+                        "max_height": "",
+                        "max_size": "",
+                        "mime_types": "png, jpg"
+                    },
+                    {
+                        "key": "field_5e976d0d22df6",
+                        "label": "Alt Text",
+                        "name": "image_alt",
+                        "type": "text",
+                        "instructions": "Text that describes the contents of the badge\/promo graphic.  <strong>Required<\/strong> for the graphic to be displayed on the degree profile.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    }
+                ]
             },
             {
-                "key": "field_5e94d0629bc99",
-                "label": "Promo Image",
-                "name": "promo_image",
-                "type": "image",
-                "instructions": "Image to be displayed at the top of the page next to the fees.",
+                "key": "field_5f9adba88bd5d",
+                "label": "Badge\/Promo 2",
+                "name": "promo_2",
+                "type": "group",
+                "instructions": "",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
-                    "width": "",
+                    "width": "50",
                     "class": "",
                     "id": ""
                 },
-                "return_format": "url",
-                "preview_size": "medium",
-                "library": "all",
-                "min_width": "",
-                "min_height": "",
-                "min_size": "",
-                "max_width": "",
-                "max_height": "",
-                "max_size": "",
-                "mime_types": "png, jpg"
-            },
-            {
-                "key": "field_5e976d0d22df6",
-                "label": "Promo Image Alt Text",
-                "name": "promo_image_alt",
-                "type": "text",
-                "instructions": "Text to be displayed as the alt text for the promo image.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "default_value": "",
-                "placeholder": "",
-                "prepend": "",
-                "append": "",
-                "maxlength": ""
+                "layout": "block",
+                "sub_fields": [
+                    {
+                        "key": "field_5f9adba98bd60",
+                        "label": "Image",
+                        "name": "image",
+                        "type": "image",
+                        "instructions": "A badge, trust symbol, or other promotional graphic relevant to this degree.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "return_format": "url",
+                        "preview_size": "medium",
+                        "library": "all",
+                        "min_width": "",
+                        "min_height": "",
+                        "min_size": "",
+                        "max_width": "",
+                        "max_height": "",
+                        "max_size": "",
+                        "mime_types": "png, jpg"
+                    },
+                    {
+                        "key": "field_5f9adba98bd61",
+                        "label": "Alt Text",
+                        "name": "image_alt",
+                        "type": "text",
+                        "instructions": "Text that describes the contents of the badge\/promo graphic.  <strong>Required<\/strong> for the graphic to be displayed on the degree profile.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    }
+                ]
             },
             {
                 "key": "field_5e99f80012a12",

--- a/includes/config.php
+++ b/includes/config.php
@@ -192,6 +192,66 @@ function define_customizer_fields( $wp_customize ) {
 		)
 	);
 
+	$wp_customize->add_setting(
+		'degrees_badge_1'
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Image_Control(
+			$wp_customize,
+			'degrees_badge_1',
+			array(
+				'label'      => 'Fallback Trust Badge 1',
+				'description' => 'A badge graphic to display on all degrees that don\'t have their own set.',
+				'section'    => THEME_CUSTOMIZER_PREFIX . 'degrees'
+			)
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_badge_1_alt'
+	);
+
+	$wp_customize->add_control(
+		'degrees_badge_1_alt',
+		array(
+			'type'        => 'text',
+			'label'       => 'Fallback Trust Badge 1 Alt Text',
+			'description' => 'Alt text for the Badge 1 graphic.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_badge_2'
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Image_Control(
+			$wp_customize,
+			'degrees_badge_2',
+			array(
+				'label'      => 'Fallback Trust Badge 2',
+				'description' => 'A badge graphic to display on all degrees that don\'t have their own set.',
+				'section'    => THEME_CUSTOMIZER_PREFIX . 'degrees'
+			)
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_badge_2_alt'
+	);
+
+	$wp_customize->add_control(
+		'degrees_badge_2_alt',
+		array(
+			'type'        => 'text',
+			'label'       => 'Fallback Trust Badge 2 Alt Text',
+			'description' => 'Alt text for the Badge 2 graphic.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
+		)
+	);
+
 	//Phonebook
 	$wp_customize->add_setting(
 		'search_service_url'

--- a/includes/config.php
+++ b/includes/config.php
@@ -201,8 +201,8 @@ function define_customizer_fields( $wp_customize ) {
 			$wp_customize,
 			'degrees_badge_1',
 			array(
-				'label'      => 'Fallback Trust Badge 1',
-				'description' => 'A badge graphic to display on all degrees that don\'t have their own set.',
+				'label'      => 'Fallback Promo/Badge 1',
+				'description' => 'A badge or other promotional graphic to display on all degrees that don\'t have their own set.',
 				'section'    => THEME_CUSTOMIZER_PREFIX . 'degrees'
 			)
 		)
@@ -216,7 +216,7 @@ function define_customizer_fields( $wp_customize ) {
 		'degrees_badge_1_alt',
 		array(
 			'type'        => 'text',
-			'label'       => 'Fallback Trust Badge 1 Alt Text',
+			'label'       => 'Fallback Promo/Badge 1 Alt Text',
 			'description' => 'Alt text for the Badge 1 graphic.',
 			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
 		)
@@ -231,8 +231,8 @@ function define_customizer_fields( $wp_customize ) {
 			$wp_customize,
 			'degrees_badge_2',
 			array(
-				'label'      => 'Fallback Trust Badge 2',
-				'description' => 'A badge graphic to display on all degrees that don\'t have their own set.',
+				'label'      => 'Fallback Promo/Badge 2',
+				'description' => 'A badge or other promotional graphic to display on all degrees that don\'t have their own set.',
 				'section'    => THEME_CUSTOMIZER_PREFIX . 'degrees'
 			)
 		)
@@ -246,7 +246,7 @@ function define_customizer_fields( $wp_customize ) {
 		'degrees_badge_2_alt',
 		array(
 			'type'        => 'text',
-			'label'       => 'Fallback Trust Badge 2 Alt Text',
+			'label'       => 'Fallback Promo/Badge 2 Alt Text',
 			'description' => 'Alt text for the Badge 2 graphic.',
 			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
 		)

--- a/includes/config.php
+++ b/includes/config.php
@@ -179,20 +179,6 @@ function define_customizer_fields( $wp_customize ) {
 	);
 
 	$wp_customize->add_setting(
-		'tuition_value_message'
-	);
-
-	$wp_customize->add_control(
-		'tuition_value_message',
-		array(
-			'type'        => 'textarea',
-			'label'       => 'Tuition Value Message',
-			'description' => 'The message displayed above the tuition per credit hour on degree pages.',
-			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
-		)
-	);
-
-	$wp_customize->add_setting(
 		'tuition_disclaimer'
 	);
 

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -117,6 +117,59 @@ function is_graduate_degree( $post ) {
 
 
 /**
+ * Returns an array of image URLs and alt text for
+ * badge graphics to display on degree profiles.
+ *
+ * @since 3.8.0
+ * @author Jo Dickson
+ * @param object $post WP_Post object
+ * @return array
+ */
+function get_degree_badges( $post=null ) {
+	$badges = array();
+
+	// Use post-specific badge, if available
+	// TODO incorporate 2nd badge field/alt options
+	if ( $post ) {
+		$post_badge_1     = get_field( 'promo_image', $post );
+		$post_badge_1_alt = get_field( 'promo_image_alt', $post );
+
+		if ( $post_badge_1 && $post_badge_1_alt ) {
+			$badges[] = array(
+				'url' => $post_badge_1,
+				'alt' => $post_badge_1_alt
+			);
+		}
+	}
+
+	// Use fallback badge(s) if there were none available
+	// for the provided $post
+	if ( empty( $badges ) ) {
+		$fallback_badge_1     = get_theme_mod( 'degrees_badge_1' );
+		$fallback_badge_1_alt = get_theme_mod( 'degrees_badge_1_alt' );
+		$fallback_badge_2     = get_theme_mod( 'degrees_badge_2' );
+		$fallback_badge_2_alt = get_theme_mod( 'degrees_badge_2_alt' );
+
+		if ( $fallback_badge_1 && $fallback_badge_1_alt ) {
+			$badges[] = array(
+				'url' => $fallback_badge_1,
+				'alt' => $fallback_badge_1_alt
+			);
+		}
+		if ( $fallback_badge_2 && $fallback_badge_2_alt ) {
+			$badges[] = array(
+				'url' => $fallback_badge_2,
+				'alt' => $fallback_badge_2_alt
+			);
+		}
+	}
+
+	return $badges;
+}
+
+
+
+/**
  * Gets the "Apply Now" button markup for degree.
  *
  * @author Jim Barnes

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -129,15 +129,22 @@ function get_degree_badges( $post=null ) {
 	$badges = array();
 
 	// Use post-specific badge, if available
-	// TODO incorporate 2nd badge field/alt options
 	if ( $post ) {
 		$post_badge_1     = get_field( 'promo_image', $post );
 		$post_badge_1_alt = get_field( 'promo_image_alt', $post );
+		$post_badge_2     = get_field( 'promo_2_image', $post );
+		$post_badge_2_alt = get_field( 'promo_2_image_alt', $post );
 
 		if ( $post_badge_1 && $post_badge_1_alt ) {
 			$badges[] = array(
 				'url' => $post_badge_1,
 				'alt' => $post_badge_1_alt
+			);
+		}
+		if ( $post_badge_2 && $post_badge_2_alt ) {
+			$badges[] = array(
+				'url' => $post_badge_2,
+				'alt' => $post_badge_2_alt
 			);
 		}
 	}

--- a/template-parts/degree-program_at_a_glance.php
+++ b/template-parts/degree-program_at_a_glance.php
@@ -15,8 +15,9 @@ if ( $post->post_type === 'degree' ) :
 
 	$tuition             = get_degree_tuition_markup( $post_meta );
 
-	$promo_image         = get_field( 'promo_image', $post );
-	$promo_image_alt     = get_field( 'promo_image_alt', $post );
+	$badges              = get_degree_badges( $post );
+	$badge_1             = $badges[0] ?? null;
+	$badge_2             = $badges[1] ?? null;
 ?>
 <section aria-label="Program at a glance">
 	<div class="jumbotron jumbotron-fluid bg-faded pb-4 pb-md-5">
@@ -58,17 +59,25 @@ if ( $post->post_type === 'degree' ) :
 				<div class="w-100 hidden-sm-down hidden-lg-up"></div>
 
 				<?php if ( $tuition ): ?>
-				<div class="col-md-7 col-lg mb-4 mb-lg-0 pr-lg-4 pr-xl-3">
+				<div class="col-md-7 col-lg mb-4 mb-lg-0 pr-lg-4">
 					<?php echo $tuition; ?>
 				</div>
 				<?php endif; ?>
 
-				<?php if ( $promo_image ) : ?>
-				<div class="col-md-5 col-lg-2 col-xl-3 mb-4 mb-lg-0 text-center d-flex align-items-center">
+				<?php if ( ! empty( $badges ) ) : ?>
+				<div class="col-md-5 col-lg-2 mb-4 mb-lg-0 text-center d-flex align-items-center">
 					<div class="row no-gutters w-100">
-						<div class="col-6 offset-3 col-sm-4 offset-sm-4 col-md-8 offset-md-2 col-lg-12 offset-lg-0 col-xl-10 offset-xl-1">
-							<img src="<?php echo $promo_image; ?>" class="img-fluid" alt="<?php echo $promo_image_alt; ?>">
+						<?php if ( $badge_1 ) : ?>
+						<div class="text-center px-2 px-md-0 d-flex align-items-center justify-content-center col col-lg-12 <?php if ( $badge_2 ) { ?>px-xl-2 mb-2<?php } ?>">
+							<img src="<?php echo $badge_1['url']; ?>" class="img-fluid" alt="<?php echo $badge_1['alt']; ?>">
 						</div>
+						<?php endif; ?>
+
+						<?php if ( $badge_2 ) : ?>
+						<div class="text-center px-2 px-md-0 px-xl-2 d-flex align-items-center justify-content-center col col-lg-12">
+							<img src="<?php echo $badge_2['url']; ?>" class="img-fluid" alt="<?php echo $badge_2['alt']; ?>">
+						</div>
+						<?php endif; ?>
 					</div>
 				</div>
 				<?php endif; ?>

--- a/template-parts/degree-program_at_a_glance.php
+++ b/template-parts/degree-program_at_a_glance.php
@@ -45,7 +45,7 @@ if ( $post->post_type === 'degree' ) :
 							</dl>
 						</div>
 						<?php if ( $program_length_image && $program_length_number && $program_length_text ) : ?>
-							<div class="col-auto pr-5 pr-sm-3 mb-4 mb-lg-0 text-center align-self-center">
+							<div class="col-auto pr-5 pr-sm-3 mb-4 mb-lg-0 text-center">
 								<div class="text-center mb-3">
 									<img class="program-length-image img-fluid" src="<?php echo $program_length_image; ?>" alt="">
 								</div>
@@ -68,13 +68,13 @@ if ( $post->post_type === 'degree' ) :
 				<div class="col-md-5 col-lg-2 mb-4 mb-lg-0 text-center d-flex align-items-center">
 					<div class="row no-gutters w-100">
 						<?php if ( $badge_1 ) : ?>
-						<div class="text-center px-2 px-md-0 d-flex align-items-center justify-content-center col col-lg-12 <?php if ( $badge_2 ) { ?>px-xl-2 mb-2<?php } ?>">
+						<div class="text-center px-2 px-lg-0 d-flex align-items-center justify-content-center col col-lg-12 <?php if ( $badge_2 ) { ?>px-xl-2 mb-2<?php } ?>">
 							<img src="<?php echo $badge_1['url']; ?>" class="img-fluid" alt="<?php echo $badge_1['alt']; ?>">
 						</div>
 						<?php endif; ?>
 
 						<?php if ( $badge_2 ) : ?>
-						<div class="text-center px-2 px-md-0 px-xl-2 d-flex align-items-center justify-content-center col col-lg-12">
+						<div class="text-center px-2 px-lg-0 px-xl-2 d-flex align-items-center justify-content-center col col-lg-12">
 							<img src="<?php echo $badge_2['url']; ?>" class="img-fluid" alt="<?php echo $badge_2['alt']; ?>">
 						</div>
 						<?php endif; ?>


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Added the ability to specify up to 2 fallback badges to display on degree profiles (in the Program at a Glance section).  Fallback badges are configurable in the Customizer.  These fallback badges will be displayed on all degree profiles unless a degree has at least one degree-specific badge set.
- A 2nd set of fields for degrees have also been added to support up to 2 degree-specific badges (previously you could only add one).
- Fields under the "Program at a Glance" tab in the degree post editor have been re-grouped for readability.

Other:
- Deleted the Tuition Value Message field in the Customizer as it's no longer in use.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of the modern template consolidation sprint.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
