### PR TITLE
Deadline template parts - first pass

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1109,7 +1109,7 @@
             {
                 "key": "field_5fa41b8492d13",
                 "label": "Alternate Section",
-                "name": "alternate_section",
+                "name": "alternate_deadlines_section",
                 "type": "post_object",
                 "instructions": "Specify an alternate Section post to display in lieu of the standard Application Deadlines section on this degree's profile.  This value takes precedence over the Undergraduate\/Graduate Fallback Section values in the Customizer.",
                 "required": 0,

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1107,11 +1107,33 @@
                 "endpoint": 0
             },
             {
+                "key": "field_5fa41b8492d13",
+                "label": "Alternate Section",
+                "name": "alternate_section",
+                "type": "post_object",
+                "instructions": "Specify an alternate Section post to display in lieu of the standard Application Deadlines section on this degree's profile.  This value takes precedence over the Undergraduate\/Graduate Fallback Section values in the Customizer.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "post_type": [
+                    "ucf_section"
+                ],
+                "taxonomy": "",
+                "allow_null": 0,
+                "multiple": 0,
+                "return_format": "id",
+                "ui": 1
+            },
+            {
                 "key": "field_5e9f44774068c",
-                "label": "Application Deadlines",
+                "label": "Deadlines",
                 "name": "application_deadlines",
                 "type": "repeater",
-                "instructions": "",
+                "instructions": "Specify a list of application deadlines to display on this degree's profile.  If provided, this list replaces the list of imported deadlines assigned to this degree.",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {

--- a/includes/config.php
+++ b/includes/config.php
@@ -14,7 +14,6 @@ define( 'THEME_CUSTOMIZER_PREFIX', 'ucf_main_site_' );
 define( 'THEME_CUSTOMIZER_DEFAULTS', serialize( array(
 	'degrees_undergraduate_application' => 'https://apply.ucf.edu/application/',
 	'degrees_graduate_application'      => 'https://application.graduate.ucf.edu/#/',
-	'degrees_visit_ucf_url'             => 'https://apply.ucf.edu/forms/campus-tour/',
 	'degrees_graduate_rfi_url_base'     => 'https://applynow.graduate.ucf.edu/register/',
 	'degrees_graduate_rfi_form_id'      => 'bad6c39a-5c60-4895-9128-5785ce014085',
 	'catalog_desc_cta_intro'            => 'A full description of this program can be found in UCF&rsquo;s catalog.',
@@ -53,11 +52,56 @@ function __init__() {
 add_action( 'after_setup_theme', '__init__' );
 
 
-function define_customizer_sections( $wp_customize ) {
-	$wp_customize->add_section(
+function define_customizer_panels( $wp_customize ) {
+	$wp_customize->add_panel(
 		THEME_CUSTOMIZER_PREFIX . 'degrees',
 		array(
 			'title' => 'Degrees'
+		)
+	);
+}
+
+add_action( 'customize_register', 'define_customizer_panels' );
+
+
+function define_customizer_sections( $wp_customize ) {
+	$wp_customize->add_section(
+		THEME_CUSTOMIZER_PREFIX . 'degrees-ctas',
+		array(
+			'title' => 'Calls to Action (CTAs)',
+			'panel' => THEME_CUSTOMIZER_PREFIX . 'degrees'
+		)
+	);
+
+	$wp_customize->add_section(
+		THEME_CUSTOMIZER_PREFIX . 'degrees-program_at_a_glance',
+		array(
+			'title' => 'Program at a Glance',
+			'panel' => THEME_CUSTOMIZER_PREFIX . 'degrees'
+		)
+	);
+
+	$wp_customize->add_section(
+		THEME_CUSTOMIZER_PREFIX . 'degrees-description',
+		array(
+			'title' => 'Description',
+			'panel' => THEME_CUSTOMIZER_PREFIX . 'degrees'
+		)
+	);
+
+	$wp_customize->add_section(
+		THEME_CUSTOMIZER_PREFIX . 'degrees-deadlines_apply',
+		array(
+			'title' => 'Application Deadlines',
+			'panel' => THEME_CUSTOMIZER_PREFIX . 'degrees'
+		)
+	);
+
+	$wp_customize->add_section(
+		THEME_CUSTOMIZER_PREFIX . 'degrees-skills_careers',
+		array(
+			'title' => 'Skills and Career Opportunities',
+			'panel' => THEME_CUSTOMIZER_PREFIX . 'degrees'
 		)
 	);
 
@@ -107,8 +151,8 @@ function define_customizer_fields( $wp_customize ) {
 		array(
 			'type'        => 'text',
 			'label'       => 'Undergraduate Application URL',
-			'description' => 'The url of the online undergraduate application.',
-			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
+			'description' => 'The URL of the online undergraduate application.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-ctas'
 		)
 	);
 
@@ -124,25 +168,8 @@ function define_customizer_fields( $wp_customize ) {
 		array(
 			'type'        => 'text',
 			'label'       => 'Graduate Application URL',
-			'description' => 'The url of the online graudate application.',
-			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
-		)
-	);
-
-	$wp_customize->add_setting(
-		'degrees_visit_ucf_url',
-		array(
-			'default' => get_theme_mod_default( 'degrees_visit_ucf_url' )
-		)
-	);
-
-	$wp_customize->add_control(
-		'degrees_visit_ucf_url',
-		array(
-			'type'        => 'text',
-			'label'       => 'Visit UCF URL',
-			'description' =>'URL for the campus tour application.',
-			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
+			'description' => 'The URL of the online graduate application.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-ctas'
 		)
 	);
 
@@ -159,7 +186,7 @@ function define_customizer_fields( $wp_customize ) {
 			'type'        => 'text',
 			'label'       => 'Graduate Degree RFI URL base',
 			'description' => 'Base URL for the request-for-information form for graduate degrees.',
-			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-ctas'
 		)
 	);
 
@@ -176,7 +203,7 @@ function define_customizer_fields( $wp_customize ) {
 			'type'        => 'text',
 			'label'       => 'Graduate Degree RFI Form ID',
 			'description' => 'ID of the request-for-information form for graduate degrees.',
-			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-ctas'
 		)
 	);
 
@@ -189,8 +216,8 @@ function define_customizer_fields( $wp_customize ) {
 		array(
 			'type'        => 'textarea',
 			'label'       => 'Tuition Disclaimer',
-			'description' => 'The message displayed below the tuition per credit hour on degree pages.',
-			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
+			'description' => 'A message displayed below the tuition per credit hour on degree pages.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-program_at_a_glance'
 		)
 	);
 
@@ -205,7 +232,7 @@ function define_customizer_fields( $wp_customize ) {
 			array(
 				'label'      => 'Fallback Promo/Badge 1',
 				'description' => 'A badge or other promotional graphic to display on all degrees that don\'t have their own set.',
-				'section'    => THEME_CUSTOMIZER_PREFIX . 'degrees'
+				'section'    => THEME_CUSTOMIZER_PREFIX . 'degrees-program_at_a_glance'
 			)
 		)
 	);
@@ -220,7 +247,7 @@ function define_customizer_fields( $wp_customize ) {
 			'type'        => 'text',
 			'label'       => 'Fallback Promo/Badge 1 Alt Text',
 			'description' => 'Alt text for the Badge 1 graphic.',
-			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-program_at_a_glance'
 		)
 	);
 
@@ -235,7 +262,7 @@ function define_customizer_fields( $wp_customize ) {
 			array(
 				'label'      => 'Fallback Promo/Badge 2',
 				'description' => 'A badge or other promotional graphic to display on all degrees that don\'t have their own set.',
-				'section'    => THEME_CUSTOMIZER_PREFIX . 'degrees'
+				'section'    => THEME_CUSTOMIZER_PREFIX . 'degrees-program_at_a_glance'
 			)
 		)
 	);
@@ -250,7 +277,7 @@ function define_customizer_fields( $wp_customize ) {
 			'type'        => 'text',
 			'label'       => 'Fallback Promo/Badge 2 Alt Text',
 			'description' => 'Alt text for the Badge 2 graphic.',
-			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-program_at_a_glance'
 		)
 	);
 
@@ -267,7 +294,7 @@ function define_customizer_fields( $wp_customize ) {
 			'type'        => 'textarea',
 			'label'       => 'Catalog CTA Intro Text',
 			'description' => 'Text to display above the "View in Catalog" button on programs that display a catalog description.',
-			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-description'
 		)
 	);
 
@@ -284,7 +311,7 @@ function define_customizer_fields( $wp_customize ) {
 			'type'        => 'textarea',
 			'label'       => 'Degree Career Fallback Intro Text',
 			'description' => 'Text to display next to a program\'s careers when a list of learnable skills is not set.',
-			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees'
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-skills_careers'
 		)
 	);
 

--- a/includes/config.php
+++ b/includes/config.php
@@ -138,7 +138,7 @@ add_action( 'customize_register', 'define_customizer_sections' );
 
 
 function define_customizer_fields( $wp_customize ) {
-	$section_choices = array();
+	$section_choices = array( '' => '---' );
 	$sections        = get_posts( array(
 		'post_type'   => 'ucf_section',
 		'numberposts' => -1,

--- a/includes/config.php
+++ b/includes/config.php
@@ -138,7 +138,22 @@ add_action( 'customize_register', 'define_customizer_sections' );
 
 
 function define_customizer_fields( $wp_customize ) {
-	// Degrees
+	$section_choices = array();
+	$sections        = get_posts( array(
+		'post_type'   => 'ucf_section',
+		'numberposts' => -1,
+		'orderby'     => 'post_title',
+		'order'       => 'ASC'
+	) );
+
+	if ( $sections ) {
+		foreach ( $sections as $section ) {
+			$section_choices[$section->ID] = $section->post_title;
+		}
+	}
+
+
+	// Degrees - CTAs
 	$wp_customize->add_setting(
 		'degrees_undergraduate_application',
 		array(
@@ -207,6 +222,7 @@ function define_customizer_fields( $wp_customize ) {
 		)
 	);
 
+	// Degrees - Program at a Glance
 	$wp_customize->add_setting(
 		'tuition_disclaimer'
 	);
@@ -281,6 +297,7 @@ function define_customizer_fields( $wp_customize ) {
 		)
 	);
 
+	// Degrees - Description
 	$wp_customize->add_setting(
 		'catalog_desc_cta_intro',
 		array(
@@ -298,6 +315,38 @@ function define_customizer_fields( $wp_customize ) {
 		)
 	);
 
+	// Degrees - Deadlines
+	$wp_customize->add_setting(
+		'degree_deadlines_undergraduate_fallback'
+	);
+
+	$wp_customize->add_control(
+		'degree_deadlines_undergraduate_fallback',
+		array(
+			'type'        => 'select',
+			'label'       => 'Undergraduate Degree Fallback Section',
+			'description' => 'An alternate Section post to display instead of the Application Deadlines section for undergraduate programs without deadlines.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-deadlines_apply',
+			'choices'     => $section_choices
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degree_deadlines_graduate_fallback'
+	);
+
+	$wp_customize->add_control(
+		'degree_deadlines_graduate_fallback',
+		array(
+			'type'        => 'select',
+			'label'       => 'Graduate Degree Fallback Section',
+			'description' => 'An alternate Section post to display instead of the Application Deadlines section for graduate programs without deadlines.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-deadlines_apply',
+			'choices'     => $section_choices
+		)
+	);
+
+	// Degrees - Skills and Career Opportunities
 	$wp_customize->add_setting(
 		'degree_careers_intro',
 		array(
@@ -315,7 +364,7 @@ function define_customizer_fields( $wp_customize ) {
 		)
 	);
 
-	//Phonebook
+	// Phonebook
 	$wp_customize->add_setting(
 		'search_service_url'
 	);

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -201,6 +201,28 @@ function get_degree_badges( $post=null ) {
 }
 
 
+/**
+ * TODO
+ *
+ * @since 3.8.0
+ * @author Jo Dickson
+ * @param object $post WP_Post object
+ * @return array
+ */
+function get_degree_application_deadlines( $post ) {
+	$deadlines = array();
+
+	if ( have_rows( 'application_deadlines', $post ) ) {
+		// Custom deadlines
+		$deadlines = get_field( 'application_deadlines', $post );
+	} else if ( have_rows( 'degree_application_deadlines', $post ) ) {
+		// Imported deadlines
+		$deadlines = get_field( 'degree_application_deadlines', $post );
+	}
+
+	return $deadlines;
+}
+
 
 /**
  * Gets the "Apply Now" button markup for degree.

--- a/template-parts/degree/deadlines_apply.php
+++ b/template-parts/degree/deadlines_apply.php
@@ -2,83 +2,81 @@
 $post = isset( $post ) ? $post : get_queried_object();
 
 if ( $post->post_type === 'degree' ) :
+	$deadlines                 = get_degree_application_deadlines( $post );
+	$deadlines_count           = is_array( $deadlines ) ? count( $deadlines ) : 0;
 	$alternate_section         = null;
 	$degree_alternate_section  = get_field( 'alternate_deadlines_section', $post );
 	$fallback_section          = is_graduate_degree( $post ) ? get_theme_mod( 'degree_deadlines_graduate_fallback' ) : get_theme_mod( 'degree_deadlines_undergraduate_fallback' );
+
 	if ( $degree_alternate_section ) {
 		$alternate_section = $degree_alternate_section;
-	} else if ( ! have_rows( 'application_deadlines' ) && ! have_rows( 'degree_application_deadlines' ) ) {
+	} else if ( ! $deadlines_count ) {
 		$alternate_section = $fallback_section;
 	}
 
 	if ( $alternate_section ) :
 		echo do_shortcode( "[ucf-section id='$alternate_section']" );
-	else:
-		$deadlines       = get_degree_application_deadlines( $post );
-		$deadlines_count = is_array( $deadlines ) ? count( $deadlines ) : 0;
-
-		if ( $deadlines_count ):
-			$deadline_heading_col_class = 'col-lg-4';
-			$deadlines_col_class = 'col-lg-8 pl-lg-5 pr-xl-5';
-			if ( $deadlines_count === 1 ) {
-				$deadline_heading_col_class = 'col-lg-7 pr-lg-3';
-				$deadlines_col_class = 'col-lg-5 pl-lg-5';
-			}
-			else if ( $deadlines_count > 2 ) {
-				$deadline_heading_col_class = 'mb-4';
-				$deadlines_col_class = 'pr-lg-5';
-			}
+	elseif ( $deadlines_count ) :
+		$deadline_heading_col_class = 'col-lg-4';
+		$deadlines_col_class = 'col-lg-8 pl-lg-5 pr-xl-5';
+		if ( $deadlines_count === 1 ) {
+			$deadline_heading_col_class = 'col-lg-7 pr-lg-3';
+			$deadlines_col_class = 'col-lg-5 pl-lg-5';
+		}
+		else if ( $deadlines_count > 2 ) {
+			$deadline_heading_col_class = 'mb-4';
+			$deadlines_col_class = 'pr-lg-5';
+		}
 ?>
-		<section aria-label="Application Deadline">
-			<div class="degree-deadline-wrap">
-				<div class="degree-deadline-row">
-					<!-- Left-hand surrounding pad, for desktop -->
-					<div class="degree-deadline-pad bg-primary"></div>
+	<section aria-label="Application Deadline">
+		<div class="degree-deadline-wrap">
+			<div class="degree-deadline-row">
+				<!-- Left-hand surrounding pad, for desktop -->
+				<div class="degree-deadline-pad bg-primary"></div>
 
-					<!-- Inner content -->
-					<div class="degree-deadline-content degree-deadline-content-deadlines text-center text-lg-left">
-						<div class="row no-gutters w-100 h-100 d-lg-flex align-items-lg-center">
-							<div class="col-12 <?php echo $deadline_heading_col_class; ?>">
-								<h2 class="h4 text-uppercase font-condensed mb-4 mb-md-5 mb-lg-0">
-									Application Deadline
-								</h2>
-							</div>
-							<div class="col-12 <?php echo $deadlines_col_class; ?>">
-								<div class="row d-lg-flex justify-content-lg-between flex-lg-nowrap">
-									<div class="col">
-										TODO
-									</div>
+				<!-- Inner content -->
+				<div class="degree-deadline-content degree-deadline-content-deadlines text-center text-lg-left">
+					<div class="row no-gutters w-100 h-100 d-lg-flex align-items-lg-center">
+						<div class="col-12 <?php echo $deadline_heading_col_class; ?>">
+							<h2 class="h4 text-uppercase font-condensed mb-4 mb-md-5 mb-lg-0">
+								Application Deadline
+							</h2>
+						</div>
+						<div class="col-12 <?php echo $deadlines_col_class; ?>">
+							<div class="row d-lg-flex justify-content-lg-between flex-lg-nowrap">
+								<div class="col">
+									TODO
 								</div>
 							</div>
 						</div>
 					</div>
-					<div class="degree-deadline-content degree-deadline-content-start text-center text-lg-left bg-gray-darker">
-						<div class="row no-gutters d-lg-flex justify-content-lg-center align-self-lg-center">
-							<div class="col-12 col-lg-auto pr-xl-4">
-								<h2 class="h5 text-uppercase font-condensed mb-4 mb-lg-3 mb-xl-0">
-									<span class="d-xl-block">Ready to</span>
-									<span class="d-xl-block">get started?</span>
-								</h2>
-							</div>
-							<div class="col-12 col-lg-auto">
-								<?php
-								echo get_degree_apply_button(
-									$post,
-									'btn btn-lg btn-primary rounded',
-									'',
-									'Apply Today'
-								);
-								?>
-							</div>
+				</div>
+				<div class="degree-deadline-content degree-deadline-content-start text-center text-lg-left bg-gray-darker">
+					<div class="row no-gutters d-lg-flex justify-content-lg-center align-self-lg-center">
+						<div class="col-12 col-lg-auto pr-xl-4">
+							<h2 class="h5 text-uppercase font-condensed mb-4 mb-lg-3 mb-xl-0">
+								<span class="d-xl-block">Ready to</span>
+								<span class="d-xl-block">get started?</span>
+							</h2>
+						</div>
+						<div class="col-12 col-lg-auto">
+							<?php
+							echo get_degree_apply_button(
+								$post,
+								'btn btn-lg btn-primary rounded',
+								'',
+								'Apply Today'
+							);
+							?>
 						</div>
 					</div>
-
-					<!-- Right-hand surrounding pad, for desktop -->
-					<div class="degree-deadline-pad bg-gray-darker"></div>
 				</div>
+
+				<!-- Right-hand surrounding pad, for desktop -->
+				<div class="degree-deadline-pad bg-gray-darker"></div>
 			</div>
-		</section>
+		</div>
+	</section>
 <?php
-		endif;
 	endif;
 endif;

--- a/template-parts/degree/deadlines_apply.php
+++ b/template-parts/degree/deadlines_apply.php
@@ -2,92 +2,83 @@
 $post = isset( $post ) ? $post : get_queried_object();
 
 if ( $post->post_type === 'degree' ) :
-	// TODO replace content for programs without deadlines, minors, ugrad certs (existing Section selection)
-	// TODO utilize imported deadline data
-	$deadlines = get_field( 'application_deadlines', $post );
-	$deadlines_count = is_array( $deadlines ) ? count( $deadlines ) : 0;
+	$alternate_section         = null;
+	$degree_alternate_section  = get_field( 'alternate_deadlines_section', $post );
+	$fallback_section          = is_graduate_degree( $post ) ? get_theme_mod( 'degree_deadlines_graduate_fallback' ) : get_theme_mod( 'degree_deadlines_undergraduate_fallback' );
+	if ( $degree_alternate_section ) {
+		$alternate_section = $degree_alternate_section;
+	} else if ( ! have_rows( 'application_deadlines' ) && ! have_rows( 'degree_application_deadlines' ) ) {
+		$alternate_section = $fallback_section;
+	}
 
-	if ( $deadlines_count ):
-		$deadline_heading_col_class = 'col-lg-4';
-		$deadlines_col_class = 'col-lg-8 pl-lg-5 pr-xl-5';
-		if ( $deadlines_count === 1 ) {
-			$deadline_heading_col_class = 'col-lg-7 pr-lg-3';
-			$deadlines_col_class = 'col-lg-5 pl-lg-5';
-		}
-		else if ( $deadlines_count > 2 ) {
-			$deadline_heading_col_class = 'mb-4';
-			$deadlines_col_class = 'pr-lg-5';
-		}
+	if ( $alternate_section ) :
+		echo do_shortcode( "[ucf-section id='$alternate_section']" );
+	else:
+		$deadlines       = get_degree_application_deadlines( $post );
+		$deadlines_count = is_array( $deadlines ) ? count( $deadlines ) : 0;
+
+		if ( $deadlines_count ):
+			$deadline_heading_col_class = 'col-lg-4';
+			$deadlines_col_class = 'col-lg-8 pl-lg-5 pr-xl-5';
+			if ( $deadlines_count === 1 ) {
+				$deadline_heading_col_class = 'col-lg-7 pr-lg-3';
+				$deadlines_col_class = 'col-lg-5 pl-lg-5';
+			}
+			else if ( $deadlines_count > 2 ) {
+				$deadline_heading_col_class = 'mb-4';
+				$deadlines_col_class = 'pr-lg-5';
+			}
 ?>
-	<section aria-label="Application Deadline">
-		<div class="degree-deadline-wrap">
-			<div class="degree-deadline-row">
-				<!-- Left-hand surrounding pad, for desktop -->
-				<div class="degree-deadline-pad bg-primary"></div>
+		<section aria-label="Application Deadline">
+			<div class="degree-deadline-wrap">
+				<div class="degree-deadline-row">
+					<!-- Left-hand surrounding pad, for desktop -->
+					<div class="degree-deadline-pad bg-primary"></div>
 
-				<!-- Inner content -->
-				<div class="degree-deadline-content degree-deadline-content-deadlines text-center text-lg-left">
-					<div class="row no-gutters w-100 h-100 d-lg-flex align-items-lg-center">
-						<div class="col-12 <?php echo $deadline_heading_col_class; ?>">
-							<h2 class="h4 text-uppercase font-condensed mb-4 mb-md-5 mb-lg-0">
-								Application Deadline
-							</h2>
-						</div>
-						<div class="col-12 <?php echo $deadlines_col_class; ?>">
-							<div class="row d-lg-flex justify-content-lg-between flex-lg-nowrap">
-							<?php while ( have_rows( 'application_deadlines', $post ) ) : the_row(); ?>
-
-								<div class="col-lg-auto my-lg-3 text-center text-uppercase">
-									<h3 class="h5">
-										<?php the_sub_field( 'deadline_term' ); ?>
-									</h3>
-									<p class="mb-0">
-										<?php the_sub_field( 'deadline' ); ?>
-									</p>
-								</div>
-
-								<?php if ( get_row_index() < $deadlines_count ): ?>
-								<div class="col-12 col-lg-auto">
-									<div class="hidden-lg-up">
-										<hr class="hr-2 hr-white w-50 my-4" role="presentational">
-									</div>
-									<div class="hidden-md-down h-100">
-										<hr class="hr-2 hr-white hr-vertical mx-0" role="presentational">
+					<!-- Inner content -->
+					<div class="degree-deadline-content degree-deadline-content-deadlines text-center text-lg-left">
+						<div class="row no-gutters w-100 h-100 d-lg-flex align-items-lg-center">
+							<div class="col-12 <?php echo $deadline_heading_col_class; ?>">
+								<h2 class="h4 text-uppercase font-condensed mb-4 mb-md-5 mb-lg-0">
+									Application Deadline
+								</h2>
+							</div>
+							<div class="col-12 <?php echo $deadlines_col_class; ?>">
+								<div class="row d-lg-flex justify-content-lg-between flex-lg-nowrap">
+									<div class="col">
+										TODO
 									</div>
 								</div>
-								<?php endif; ?>
-
-							<?php endwhile; ?>
 							</div>
 						</div>
 					</div>
-				</div>
-				<div class="degree-deadline-content degree-deadline-content-start text-center text-lg-left bg-gray-darker">
-					<div class="row no-gutters d-lg-flex justify-content-lg-center align-self-lg-center">
-						<div class="col-12 col-lg-auto pr-xl-4">
-							<h2 class="h5 text-uppercase font-condensed mb-4 mb-lg-3 mb-xl-0">
-								<span class="d-xl-block">Ready to</span>
-								<span class="d-xl-block">get started?</span>
-							</h2>
-						</div>
-						<div class="col-12 col-lg-auto">
-							<?php
-							echo get_degree_apply_button(
-								$post,
-								'btn btn-lg btn-primary rounded',
-								'',
-								'Apply Today'
-							);
-							?>
+					<div class="degree-deadline-content degree-deadline-content-start text-center text-lg-left bg-gray-darker">
+						<div class="row no-gutters d-lg-flex justify-content-lg-center align-self-lg-center">
+							<div class="col-12 col-lg-auto pr-xl-4">
+								<h2 class="h5 text-uppercase font-condensed mb-4 mb-lg-3 mb-xl-0">
+									<span class="d-xl-block">Ready to</span>
+									<span class="d-xl-block">get started?</span>
+								</h2>
+							</div>
+							<div class="col-12 col-lg-auto">
+								<?php
+								echo get_degree_apply_button(
+									$post,
+									'btn btn-lg btn-primary rounded',
+									'',
+									'Apply Today'
+								);
+								?>
+							</div>
 						</div>
 					</div>
-				</div>
 
-				<!-- Right-hand surrounding pad, for desktop -->
-				<div class="degree-deadline-pad bg-gray-darker"></div>
+					<!-- Right-hand surrounding pad, for desktop -->
+					<div class="degree-deadline-pad bg-gray-darker"></div>
+				</div>
 			</div>
-		</div>
-	</section>
+		</section>
 <?php
+		endif;
 	endif;
 endif;


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Added the ability to specify alternate sections to display in lieu of Application Deadlines on degree profiles.  Two new Customizer options have been added (one for undergraduate degrees w/no deadlines, and one for graduate w/no deadlines), as well as a new ACF field for degree-specific overrides.
- Re-grouped Customizer options for degrees into panels to tidy things up a bit
- Modified the Application Deadlines template part to only display the actual deadlines section when deadlines are available and a degree-specific section override hasn't been provided.

Actual display of deadlines is not functional at this point; I'll be filling in the new `get_degree_application_deadlines()` and adding display logic in a future PR.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of initial degree template consolidation sprint.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
