### PR TITLE
Degree descriptions - catalog sidebar promos

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1035,6 +1035,58 @@
                 ]
             },
             {
+                "key": "field_5faeb8ce5d327",
+                "label": "Catalog Description",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "left",
+                "endpoint": 0
+            },
+            {
+                "key": "field_5faebbbb92089",
+                "label": "",
+                "name": "",
+                "type": "message",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "<em>Note: these settings only apply to degrees that display a catalog description (i.e. don't have a custom Degree Description set.)<\/em>",
+                "new_lines": "wpautop",
+                "esc_html": 0
+            },
+            {
+                "key": "field_5faeb73f9e0c7",
+                "label": "Disable Sidebar Promo",
+                "name": "degree_disable_sidebar_promo",
+                "type": "true_false",
+                "instructions": "If checked, the promo graphic set in the Customizer for this type of degree will <em>not<\/em> be displayed on this degree's profile.  Only applicable when this degree displays a catalog description (and not a custom description).",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "",
+                "default_value": 0,
+                "ui": 1,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            },
+            {
                 "key": "field_5e99f80012a12",
                 "label": "Degree Description & Highlights",
                 "name": "",

--- a/includes/config.php
+++ b/includes/config.php
@@ -299,6 +299,152 @@ function define_customizer_fields( $wp_customize ) {
 
 	// Degrees - Description
 	$wp_customize->add_setting(
+		'degrees_sidebar_promo_undergraduate'
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Image_Control(
+			$wp_customize,
+			'degrees_sidebar_promo_undergraduate',
+			array(
+				'label'       => 'Undergraduate Promo Graphic',
+				'description' => 'An image or other promotional graphic to display alongside undergraduate catalog descriptions.',
+				'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-description'
+			)
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_sidebar_promo_undergraduate_alt'
+	);
+
+	$wp_customize->add_control(
+		'degrees_sidebar_promo_undergraduate_alt',
+		array(
+			'type'        => 'text',
+			'label'       => 'Undergraduate Promo Graphic Alt Text',
+			'description' => 'Alt text for the Undergraduate Promo graphic.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-description'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_sidebar_promo_undergraduate_link_url'
+	);
+
+	$wp_customize->add_control(
+		'degrees_sidebar_promo_undergraduate_link_url',
+		array(
+			'type'        => 'text',
+			'label'       => 'Undergraduate Promo Link URL',
+			'description' => 'An optional URL for the Undergraduate Promo graphic to link out to.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-description'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_sidebar_promo_undergraduate_link_rel'
+	);
+
+	$wp_customize->add_control(
+		'degrees_sidebar_promo_undergraduate_link_rel',
+		array(
+			'type'        => 'text',
+			'label'       => 'Undergraduate Promo Link Rel Attribute',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-description'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_sidebar_promo_undergraduate_link_new_window',
+		array(
+			'default' => 0
+		)
+	);
+
+	$wp_customize->add_control(
+		'degrees_sidebar_promo_undergraduate_link_new_window',
+		array(
+			'type'        => 'checkbox',
+			'label'       => 'Undergraduate Promo Link - Open in New Window',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-description'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_sidebar_promo_graduate'
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Image_Control(
+			$wp_customize,
+			'degrees_sidebar_promo_graduate',
+			array(
+				'label'       => 'Graduate Promo Graphic',
+				'description' => 'An image or other promotional graphic to display alongside graduate catalog descriptions.',
+				'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-description'
+			)
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_sidebar_promo_graduate_alt'
+	);
+
+	$wp_customize->add_control(
+		'degrees_sidebar_promo_graduate_alt',
+		array(
+			'type'        => 'text',
+			'label'       => 'Graduate Promo Graphic Alt Text',
+			'description' => 'Alt text for the Graduate Promo graphic.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-description'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_sidebar_promo_graduate_link_url'
+	);
+
+	$wp_customize->add_control(
+		'degrees_sidebar_promo_graduate_link_url',
+		array(
+			'type'        => 'text',
+			'label'       => 'Graduate Promo Link URL',
+			'description' => 'An optional URL for the Graduate Promo graphic to link out to.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-description'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_sidebar_promo_graduate_link_rel'
+	);
+
+	$wp_customize->add_control(
+		'degrees_sidebar_promo_graduate_link_rel',
+		array(
+			'type'        => 'text',
+			'label'       => 'Graduate Promo Link Rel Attribute',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-description'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_sidebar_promo_graduate_link_new_window',
+		array(
+			'default' => 0
+		)
+	);
+
+	$wp_customize->add_control(
+		'degrees_sidebar_promo_graduate_link_new_window',
+		array(
+			'type'        => 'checkbox',
+			'label'       => 'Graduate Promo Link - Open in New Window',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-description'
+		)
+	);
+
+	$wp_customize->add_setting(
 		'catalog_desc_cta_intro',
 		array(
 			'default' => get_theme_mod_default( 'catalog_desc_cta_intro' )

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -277,14 +277,17 @@ function get_degree_badges( $post=null ) {
  * @return array
  */
 function get_degree_promo( $post ) {
-	$promo = array();
+	$promo               = array();
+	$disable_promo       = get_field( 'degree_disable_sidebar_promo', $post ) ?: false;
 	$theme_mod_name_base = '';
-	$promo_img = null;
+	$promo_img           = null;
 
-	if ( is_graduate_degree( $post ) ) {
-		$theme_mod_name_base = 'degrees_sidebar_promo_graduate';
-	} else if ( is_undergraduate_degree( $post ) ) {
-		$theme_mod_name_base = 'degrees_sidebar_promo_undergraduate';
+	if ( ! $disable_promo ) {
+		if ( is_graduate_degree( $post ) ) {
+			$theme_mod_name_base = 'degrees_sidebar_promo_graduate';
+		} else if ( is_undergraduate_degree( $post ) ) {
+			$theme_mod_name_base = 'degrees_sidebar_promo_undergraduate';
+		}
 	}
 
 	if ( $theme_mod_name_base ) {

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -102,13 +102,36 @@ function is_graduate_degree( $post ) {
 	$is_graduate = false;
 	$terms = wp_get_post_terms( $post->ID, 'program_types' );
 
-	foreach( $terms as $term ) {
-		if( $term->slug === "graduate-program" ) {
+	foreach ( $terms as $term ) {
+		if ( $term->slug === 'graduate-program' ) {
 			$is_graduate = true;
 			break;
 		}
 	}
 	return $is_graduate;
+}
+
+
+/**
+ * Returns true/false if the given degree $post is
+ * an undergraduate program.
+ *
+ * @since 3.8.0
+ * @author Jo Dickson
+ * @param object $post  WP_Post object
+ * @return boolean
+ */
+function is_undergraduate_degree( $post ) {
+	$is_undergraduate = false;
+	$terms = wp_get_post_terms( $post->ID, 'program_types' );
+
+	foreach ( $terms as $term ) {
+		if ( $term->slug === 'undergraduate-program' ) {
+			$is_undergraduate = true;
+			break;
+		}
+	}
+	return $is_undergraduate;
 }
 
 
@@ -226,6 +249,44 @@ function get_degree_badges( $post=null ) {
 	}
 
 	return $badges;
+}
+
+
+/**
+ * Returns details for a promotional graphic to display
+ * alongside degree catalog descriptions.
+ *
+ * @since 3.8.0
+ * @author Jo Dickson
+ * @param object $post WP_Post object
+ * @return array
+ */
+function get_degree_promo( $post ) {
+	$promo = array();
+	$theme_mod_name_base = '';
+	$promo_img = null;
+
+	if ( is_graduate_degree( $post ) ) {
+		$theme_mod_name_base = 'degrees_sidebar_promo_graduate';
+	} else if ( is_undergraduate_degree( $post ) ) {
+		$theme_mod_name_base = 'degrees_sidebar_promo_undergraduate';
+	}
+
+	if ( $theme_mod_name_base ) {
+		$promo_img = get_theme_mod( $theme_mod_name_base );
+	}
+
+	if ( $promo_img ) {
+		$promo = array(
+			'img'        => $promo_img,
+			'alt'        => get_theme_mod( $theme_mod_name_base . '_alt', '' ),
+			'link_url'   => get_theme_mod( $theme_mod_name_base . '_link_url', '' ),
+			'link_rel'   => get_theme_mod( $theme_mod_name_base . '_link_rel', '' ),
+			'new_window' => get_theme_mod( $theme_mod_name_base . '_link_new_window', false ),
+		);
+	}
+
+	return $promo;
 }
 
 

--- a/template-parts/degree/deadlines_apply.php
+++ b/template-parts/degree/deadlines_apply.php
@@ -5,11 +5,22 @@ if ( $post->post_type === 'degree' ) :
 	$deadlines                 = get_degree_application_deadlines( $post );
 	$alternate_section         = null;
 	$degree_alternate_section  = get_field( 'alternate_deadlines_section', $post );
-	$fallback_section          = is_graduate_degree( $post ) ? get_theme_mod( 'degree_deadlines_graduate_fallback' ) : get_theme_mod( 'degree_deadlines_undergraduate_fallback' );
 
+	// Retrieve a fallback section
+	$fallback_section_name = '';
+	if ( is_graduate_degree( $post ) ) {
+		$fallback_section_name = 'degree_deadlines_graduate_fallback';
+	} elseif ( is_undergraduate_degree( $post ) ) {
+		$fallback_section_name = 'degree_deadlines_undergraduate_fallback';
+	}
+	$fallback_section = $fallback_section_name ? get_theme_mod( $fallback_section_name ) : null;
+
+	// Set $alternate_section to the degree-specific
+	// alternate Section post that's set, or a fallback
+	// if deadlines aren't available:
 	if ( $degree_alternate_section ) {
 		$alternate_section = $degree_alternate_section;
-	} else if ( ! $deadlines ) {
+	} elseif ( ! $deadlines ) {
 		$alternate_section = $fallback_section;
 	}
 
@@ -20,7 +31,7 @@ if ( $post->post_type === 'degree' ) :
 
 		// Modify heading text depending on the type of degree:
 		$heading_text = '<span class="d-inline-block">Application Deadlines</span>';
-		if ( ! is_graduate_degree( $post ) ) {
+		if ( is_undergraduate_degree( $post ) ) {
 			$heading_text = 'Undergraduate ' . $heading_text;
 		}
 

--- a/template-parts/degree/description/sidebar.php
+++ b/template-parts/degree/description/sidebar.php
@@ -10,6 +10,7 @@ if ( $post->post_type === 'degree' ) :
 		'numberposts' => -1,
 		'post_status' => 'publish'
 	) );
+	$promo             = get_degree_promo( $post );
 
 	if ( $catalog_url || $subplans ) :
 ?>
@@ -17,6 +18,26 @@ if ( $post->post_type === 'degree' ) :
 		<div class="degree-catalog-sidebar pt-lg-3">
 
 			<hr class="mb-4 mb-sm-5 hidden-lg-up" role="presentation">
+
+			<?php if ( $promo ) : ?>
+			<div class="text-center">
+
+				<?php if ( $promo['link_url'] ) : ?>
+				<a href="<?php echo $promo['link_url']; ?>"
+					<?php if ( $promo['link_rel'] ) { ?>rel="<?php echo $promo['link_rel']; ?>"<?php } ?>
+					<?php if ( $promo['new_window'] ) { ?>target="_blank"<?php } ?>>
+				<?php endif; ?>
+					<img class="img-fluid" src="<?php echo $promo['img']; ?>" alt="<?php echo $promo['alt']; ?>">
+				<?php if ( $promo['link_url'] ) : ?>
+				</a>
+				<?php endif; ?>
+
+			</div>
+			<?php endif; ?>
+
+			<?php if ( $promo && $catalog_url ) : ?>
+			<hr class="my-4 my-sm-5" role="presentation">
+			<?php endif; ?>
 
 			<?php if ( $catalog_url ) : ?>
 			<div class="row py-3 py-sm-0">

--- a/template-parts/degree/description/sidebar.php
+++ b/template-parts/degree/description/sidebar.php
@@ -19,64 +19,79 @@ if ( $post->post_type === 'degree' ) :
 
 			<hr class="mb-4 mb-sm-5 hidden-lg-up" role="presentation">
 
-			<?php if ( $promo ) : ?>
-			<div class="text-center">
+			<div class="row">
 
-				<?php if ( $promo['link_url'] ) : ?>
-				<a href="<?php echo $promo['link_url']; ?>"
-					<?php if ( $promo['link_rel'] ) { ?>rel="<?php echo $promo['link_rel']; ?>"<?php } ?>
-					<?php if ( $promo['new_window'] ) { ?>target="_blank"<?php } ?>>
-				<?php endif; ?>
-					<img class="img-fluid" src="<?php echo $promo['img']; ?>" alt="<?php echo $promo['alt']; ?>">
-				<?php if ( $promo['link_url'] ) : ?>
-				</a>
-				<?php endif; ?>
+				<?php if ( $catalog_url ) : ?>
+				<div class="col-12">
+					<div class="row py-3 py-sm-0">
 
-			</div>
-			<?php endif; ?>
+						<?php if ( $catalog_cta_intro ) : ?>
+						<div class="col-auto pr-0">
+							<span class="fa fa-info-circle text-info fa-3x" aria-hidden="true"></span>
+						</div>
+						<div class="col d-flex align-self-center">
+							<p class="degree-catalog-cta-info mb-0">
+								<?php echo $catalog_cta_intro; ?>
+							</p>
+						</div>
+						<div class="w-100 mb-4"></div>
+						<?php endif; ?>
 
-			<?php if ( $promo && $catalog_url ) : ?>
-			<hr class="my-4 my-sm-5" role="presentation">
-			<?php endif; ?>
+						<div class="col col-sm-8 col-md-6 col-lg">
+							<a href="<?php echo $catalog_url; ?>" target="_blank" class="btn btn-block btn-outline-info rounded py-3">View in Catalog</a>
+						</div>
 
-			<?php if ( $catalog_url ) : ?>
-			<div class="row py-3 py-sm-0">
-
-				<?php if ( $catalog_cta_intro ) : ?>
-				<div class="col-auto pr-0">
-					<span class="fa fa-info-circle text-info fa-3x" aria-hidden="true"></span>
+					</div>
 				</div>
-				<div class="col d-flex align-self-center">
-					<p class="degree-catalog-cta-info mb-0">
-						<?php echo $catalog_cta_intro; ?>
-					</p>
-				</div>
-				<div class="w-100 mb-4"></div>
 				<?php endif; ?>
 
-				<div class="col col-sm-8 col-md-6 col-lg">
-					<a href="<?php echo $catalog_url; ?>" target="_blank" class="btn btn-block btn-outline-info rounded py-3">View in Catalog</a>
+				<?php if ( $catalog_url && $subplans ) : ?>
+				<div class="col-12">
+					<hr class="my-4 my-sm-5" role="presentation">
 				</div>
+				<?php endif; ?>
 
-			</div>
-			<?php endif; ?>
+				<?php if ( $subplans ) : ?>
+				<div class="col-12">
+					<h2 class="h6 text-uppercase text-default pt-3 pt-sm-0 mb-4 pb-md-2">Program Tracks/Options</h2>
+					<ul class="list-unstyled">
+						<?php foreach ( $subplans as $subplan ) : ?>
+						<li class="d-block degree-title mb-3 mb-md-4">
+							<a href="<?php echo get_permalink( $subplan ); ?>">
+								<?php echo get_field( 'degree_name_short', $subplan ) ?: $subplan->post_title; ?>
+							</a>
+						</li>
+						<?php endforeach; ?>
+					</ul>
+				</div>
+				<?php endif; ?>
 
-			<?php if ( $catalog_url && $subplans ) : ?>
-			<hr class="my-4 my-sm-5" role="presentation">
-			<?php endif; ?>
+				<?php if ( $promo ) : ?>
+				<div class="col-12 text-center flex-lg-first">
 
-			<?php if ( $subplans ) : ?>
-			<h2 class="h6 text-uppercase text-default pt-3 pt-sm-0 mb-4 pb-md-2">Program Tracks/Options</h2>
-			<ul class="list-unstyled">
-				<?php foreach ( $subplans as $subplan ) : ?>
-				<li class="d-block degree-title mb-3 mb-md-4">
-					<a href="<?php echo get_permalink( $subplan ); ?>">
-						<?php echo get_field( 'degree_name_short', $subplan ) ?: $subplan->post_title; ?>
+					<?php if ( $catalog_url || $subplans ) : ?>
+					<hr class="hidden-lg-up my-4 my-sm-5 pb-2 pb-sm-0" role="presentation">
+					<?php endif; ?>
+
+					<?php if ( $promo['link_url'] ) : ?>
+					<a class="d-inline-block"
+						href="<?php echo $promo['link_url']; ?>"
+						<?php if ( $promo['link_rel'] ) { ?>rel="<?php echo $promo['link_rel']; ?>"<?php } ?>
+						<?php if ( $promo['new_window'] ) { ?>target="_blank"<?php } ?>>
+					<?php endif; ?>
+						<img class="img-fluid" src="<?php echo $promo['img']; ?>" alt="<?php echo $promo['alt']; ?>">
+					<?php if ( $promo['link_url'] ) : ?>
 					</a>
-				</li>
-				<?php endforeach; ?>
-			</ul>
-			<?php endif; ?>
+					<?php endif; ?>
+
+					<?php if ( $catalog_url || $subplans ) : ?>
+					<hr class="hidden-md-down my-5" role="presentation">
+					<?php endif; ?>
+
+				</div>
+				<?php endif; ?>
+
+			</div>
 
 		</div>
 	</div>


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Added Customizer options for defining "promo" graphics that display next to catalog descriptions.  Undergraduate and graduate programs have separate promo options.  All degrees that display a catalog description will display a respective promo, unless disabled per-degree (see below).
- Added ACF field for disabling sidebar promos on a per-degree basis.
- Added `is_undergraduate_degree()` to explicitly distinguish these types of degrees, and removed logic throughout the theme that assumes `! is_graduate_degree()` equates to an undergraduate program (to better account for professional programs, which don't fall under either of these types).

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of initial degree template consolidation sprint.  Feature requested by Roger.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
