### PR TITLE
Add custom Yoast variable for degree program_type

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -1107,6 +1107,7 @@ function get_yoast_title_degree_program_type() {
 	}
 }
 
+
 /**
  * Registers the Yoast variable additions.
  * NOTE: The snippet preview in the backend will show the custom variable markup

--- a/includes/config.php
+++ b/includes/config.php
@@ -1081,6 +1081,48 @@ add_filter( 'wpseo_sitemap_exclude_empty_terms', 'yoast_sitemap_empty_terms', 10
 
 
 /**
+ * Returns a degree's program type formatted to be used
+ * as a custom variable in Yoast titles and descriptions.
+ *
+ * @since v3.8.2
+ * @author Cadie Stockman
+ * @return string program type title
+ */
+function get_yoast_title_degree_program_type() {
+	global $post;
+	if ( ! $post || $post->post_type !== 'degree' ) return;
+
+	$program_type = get_degree_program_type( $post );
+
+	switch ( $program_type->name ) {
+		case 'Master':
+			return 'Master\'s Degree';
+			break;
+		case 'Bachelor':
+			return 'Bachelor\'s Degree';
+			break;
+		default:
+			return $program_type->name;
+			break;
+	}
+}
+
+/**
+ * Registers the Yoast variable additions.
+ * NOTE: The snippet preview in the backend will show the custom variable markup
+ * (i.e. '%%program_type%%') but the variable's output will be utilized on the front-end.
+ *
+ * @since v3.8.2
+ * @author Cadie Stockman
+ */
+function yoast_register_variables() {
+    wpseo_register_var_replacement( '%%program_type%%', 'get_yoast_title_degree_program_type', 'advanced', 'Provides a program_type string for usage in degree titles.' );
+}
+
+add_action( 'wpseo_register_extra_replacements', 'yoast_register_variables' );
+
+
+/**
  * Ensures that only published degrees are available to
  * select from when picking existing degrees for Colleges'
  * "Top Degrees" lists.


### PR DESCRIPTION
**Description**
Adds a custom Yoast variable `%%program_type%%` that customizes and outputs the degree's program type in order to be used in degree post's titles and meta descriptions.

**Motivation and Context**
A way of utilizing a degree's program type in the Yoast template was requested so that title and meta descriptions could be templatized for degrees in the Yoast settings. 'Master' and 'Bachelor' were requested to return differently in order to work with the Yoast title and description templates.

Yoast currently has a variable for custom taxonomies that you can use, but it returns them as a comma-separated list.

**How Has This Been Tested?**
Changes viewable in Dev. Test links are given in Slack.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
