### PR TITLE
Removed deregister of wp-polyfill and wp-dom-ready

### DIFF
--- a/includes/meta.php
+++ b/includes/meta.php
@@ -49,8 +49,6 @@ function enqueue_frontend_assets() {
 		&& $allow_user_editor_choice !== 'allow'
 	) {
 		wp_deregister_style( 'wp-block-library' );
-		wp_deregister_script( 'wp-polyfill' );
-		wp_deregister_script( 'wp-dom-ready' );
 	}
 }
 

--- a/includes/meta.php
+++ b/includes/meta.php
@@ -28,7 +28,6 @@ function enqueue_frontend_assets() {
 		wp_enqueue_script( 'ucf-header', '//universityheader.ucf.edu/bar/js/university-header.js?use-1200-breakpoint=1', null, null, true );
 	}
 
-	wp_enqueue_script( 'wp-a11y' );
 	wp_enqueue_script( 'tether', 'https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js', null, null, true );
 	wp_enqueue_script( 'script', THEME_JS_URL . '/script.min.js', array( 'jquery', 'tether' ), $theme_version, true );
 


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.  **Updated:** Also removes `wp-a11y` enqueue.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
~Unfortunately these scripts are dependencies of `wp-a11y`, which we require in the Degree Search Plugin's angular app, and deregistering/dequeuing these scripts in the theme prevents the plugin from loading the dependencies correctly, even after adjusting `wp_enqueue_scripts` hook priority levels. :(~

Turns out we had a `wp-a11y` enqueue in the theme I missed, which explains why things with `wp-polyfill` and `wp-dom-ready` were so janky.  It looks like `wp-a11y` was only ever in use for the Angular degree search, and that dependency has been moved into that plugin: https://github.com/UCF/UCF-Degree-Search-Plugin/pull/92

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
