### PR TITLE
Statement archive template - first pass

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -14,6 +14,7 @@ include_once THEME_DIR . 'includes/degree-import-functions.php';
 include_once THEME_DIR . 'includes/degree-search-functions.php';
 include_once THEME_DIR . 'includes/ucf-alert-functions.php';
 include_once THEME_DIR . 'includes/phonebook-functions.php';
+include_once THEME_DIR . 'includes/statements-functions.php';
 include_once THEME_DIR . 'includes/post-list-layouts.php';
 
 

--- a/includes/config.php
+++ b/includes/config.php
@@ -32,7 +32,8 @@ define( 'THEME_CUSTOMIZER_DEFAULTS', serialize( array(
 	'location_fallback_image'           => '',
 	'chartbeat_uid'                     => '2806',
 	'chartbeat_domain'                  => 'ucf.edu',
-	'search_service_url'                => 'https://search.smca.ucf.edu/service.php'
+	'search_service_url'                => 'https://search.smca.ucf.edu/service.php',
+	'statements_page_path'              => 'statements'
 ) ) );
 
 function __init__() {
@@ -116,6 +117,13 @@ function define_customizer_sections( $wp_customize ) {
 		THEME_CUSTOMIZER_PREFIX . 'phonebook',
 		array(
 			'title' => 'Phonebook'
+		)
+	);
+
+	$wp_customize->add_section(
+		THEME_CUSTOMIZER_PREFIX . 'statements',
+		array(
+			'title' => 'Statements Archive'
 		)
 	);
 
@@ -656,6 +664,38 @@ function define_customizer_fields( $wp_customize ) {
 			'label'       => 'Search Service URL',
 			'description' => 'The base url of the UCF Search service.',
 			'section'     => THEME_CUSTOMIZER_PREFIX . 'phonebook'
+		)
+	);
+
+	// Phonebook
+	$wp_customize->add_setting(
+		'statements_page_path',
+		array(
+			'default' => get_theme_mod_default( 'statements_page_path' )
+		)
+	);
+
+	$wp_customize->add_control(
+		'statements_page_path',
+		array(
+			'type'        => 'text',
+			'label'       => 'Statements Page Path',
+			'description' => 'Relative path from the main site root that the Statements page lives at.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'statements'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'statements_archive_endpoint'
+	);
+
+	$wp_customize->add_control(
+		'statements_archive_endpoint',
+		array(
+			'type'        => 'text',
+			'label'       => 'Statements Archive API Endpoint',
+			'description' => 'URL to the API endpoint that lists Statement data by year and author.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'statements'
 		)
 	);
 

--- a/includes/statements-functions.php
+++ b/includes/statements-functions.php
@@ -204,7 +204,7 @@ function get_statement_author_data( $author ) {
  * @author Jo Dickson
  * @return array
  */
-function get_statement_data() {
+function get_statements() {
 	$endpoint = '';
 	$q_year   = intval( get_query_var( 'by-year' ) );
 	$q_author = get_query_var( 'tu_author' );
@@ -228,20 +228,23 @@ function get_statement_data() {
 	// back out:
 	if ( ! $endpoint ) return null;
 
-	// TODO utilize transients
+	// TODO pagination
+
 	return main_site_get_remote_response_json( $endpoint, null );
 }
 
 
 /**
- * Returns markup for a list of statements. TODO
+ * Returns markup for a list of statements.
+ * TODO styling
+ * TODO pagination
  *
  * @since 3.9.0
  * @author Jo Dickson
  * @return string
  */
-function get_statements() {
-	$statements = get_statement_data();
+function get_statements_list() {
+	$statements = get_statements();
 	ob_start();
 ?>
 	<?php if ( $statements ) : ?>

--- a/includes/statements-functions.php
+++ b/includes/statements-functions.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Responsible for statement archive related functionality
+ **/
+
+/**
+ * Registers custom rewrite rules to support filtering options
+ * on the statements page without straight query params.
+ *
+ * @since 3.9.0
+ * @author Jo Dickson
+ * @return void
+ */
+function register_statement_rewrite_rules() {
+	$statements_pg_path = untrailingslashit( get_theme_mod_or_default( 'statements_page_path' ) );
+	if ( ! $statements_pg_path ) return;
+
+	$statements_pg = get_page_by_path( $statements_pg_path );
+	if ( $statements_pg ) {
+		add_rewrite_rule( '^' . $statements_pg_path . '/year/([0-9]{4})[/]?$', 'index.php?page_id=' . $statements_pg->ID . '&by-year=$matches[1]', 'top' );
+		add_rewrite_rule( '^' . $statements_pg_path . '/author/([a-z0-9_-]+)[/]?$', 'index.php?page_id=' . $statements_pg->ID . '&tu_author=$matches[1]', 'top' );
+	}
+}
+
+add_action( 'init', 'register_statement_rewrite_rules' );
+
+
+/**
+ * Registers query vars for the statements page
+ * so that WP query var functions recognize them.
+ *
+ * @since 3.9.0
+ * @author Jo Dickson
+ * @param array $query_vars Existing public query vars
+ * @return array Modified query vars
+ */
+function register_statement_query_vars( $query_vars ) {
+	$query_vars[] = 'by-year';
+	$query_vars[] = 'tu_author';
+	return $query_vars;
+}
+
+add_filter( 'query_vars', 'register_statement_query_vars', 10, 1 );
+
+
+/**
+ * Handles various redirects for loading filtered statement content
+ *
+ * @since 3.9.0
+ * @author Jo Dickson
+ * @return void
+ */
+function statement_redirects() {
+	$statements_pg_path = untrailingslashit( get_theme_mod_or_default( 'statements_page_path' ) );
+	if ( ! $statements_pg_path ) return;
+
+	$statements_pg = get_page_by_path( $statements_pg_path );
+	if ( $statements_pg && is_page( $statements_pg->ID ) ) {
+		$should_redirect = false;
+		$year            = get_query_var( 'by-year' );
+		$author          = get_query_var( 'tu_author' );
+
+		// Redirect requests for /{statements_pg_path}/author/ and
+		// /{statements_pg_path}/year/ with bogus/invalid values
+		if (
+			( $year && ! statement_year_is_valid( $year ) )
+			|| ( $author && ! statement_author_is_valid( $author ) )
+		) {
+			$should_redirect = true;
+		}
+
+		if ( $should_redirect ) {
+			// TODO this works for now, but would be nice
+			// if these 404'd instead. This hook doesn't
+			// appear to fire early enough, and the "Statements"
+			// h1 gets printed above the 404 template content.
+			wp_redirect( get_permalink( $statements_pg ) );
+			exit();
+			// global $wp_query;
+			// $wp_query->set_404();
+			// status_header( 404 );
+			// get_template_part( 404 );
+			// exit();
+		}
+	}
+}
+
+add_action( 'template_redirect', 'statement_redirects', 999 );
+
+
+/**
+ * Returns whether or not the provided year has
+ * statement data available.
+ *
+ * @since 3.9.0
+ * @author Jo Dickson
+ * @param int|string $year A year
+ * @return bool
+ */
+function statement_year_is_valid( $year ) {
+	if ( ! $year ) return false;
+	$year = intval( $year );
+
+	$archive_data = get_statement_archive_data();
+	if ( ! $archive_data || ! property_exists( $archive_data, 'years' ) ) return false;
+
+	if ( in_array(
+		$year,
+		array_column( $archive_data->years, 'year' )
+	) ) {
+		return true;
+	}
+	return false;
+}
+
+
+/**
+ * Returns whether or not the provided author has
+ * statement data available.
+ *
+ * @since 3.9.0
+ * @author Jo Dickson
+ * @param string $author An author slug
+ * @return bool
+ */
+function statement_author_is_valid( $author ) {
+	if ( ! $author ) return false;
+
+	$archive_data = get_statement_archive_data();
+	if ( ! $archive_data || ! property_exists( $archive_data, 'authors' ) ) return false;
+
+	if ( in_array(
+		$author,
+		array_column( $archive_data->authors, 'slug' )
+	) ) {
+		return true;
+	}
+	return false;
+}
+
+
+/**
+ * Returns data for available statement archive endpoints.
+ * References transient data, if available.
+ *
+ * @since 3.9.0
+ * @author Jo Dickson
+ * @return array
+ */
+function get_statement_archive_data() {
+	$endpoint = get_theme_mod( 'statements_archive_endpoint' );
+	if ( ! $endpoint ) return array();
+
+	$data = array();
+
+	$transient = get_transient( 'statements_archive_data' );
+	if ( $transient ) {
+		$data = $transient;
+	} else {
+		$data = main_site_get_remote_response_json( $endpoint, array() );
+		if ( $data ) {
+			// Store transient data for 5 minutes (300 seconds)
+			// TODO allow transient expiration to be configured
+			set_transient( 'statements_archive_data', $data, 300 );
+		}
+	}
+
+	return $data;
+}
+
+
+/**
+ * Returns markup for a list of statements. TODO
+ *
+ * @since 3.9.0
+ * @author Jo Dickson
+ * @return string
+ */
+function get_statements( $archive_data ) {
+	return '';
+}
+
+
+/**
+ * Returns markup for filtering statements.
+ * TODO add expand/collapse at -xs-md
+ *
+ * @since 3.9.0
+ * @author Jo Dickson
+ * @return string
+ */
+function get_statement_filters( $archive_data ) {
+	global $post;
+	if ( ! $post ) return '';
+
+	$years   = $archive_data->years ?? array();
+	$authors = $archive_data->authors ?? array();
+
+	ob_start();
+?>
+	<?php if ( $years ) : ?>
+	<div class="mb-4 mb-sm-5">
+		<h2 class="h6 text-uppercase letter-spacing-3 mb-4">By Year</h2>
+		<ul class="nav nav-pills flex-column">
+			<?php
+			foreach ( $years as $year ) :
+				$year_link = get_permalink( $post ) . 'year/' . $year->year . '/';
+			?>
+			<li class="nav-item">
+				<a class="nav-link w-100" href="<?php echo $year_link; ?>">
+					<?php echo $year->year; ?>
+				</a>
+			</li>
+			<?php endforeach; ?>
+		</ul>
+	</div>
+	<?php endif; ?>
+
+	<?php if ( $authors ) : ?>
+	<div class="mb-4 mb-sm-5">
+		<h2 class="h6 text-uppercase letter-spacing-3 mb-4">Statements Issued By</h2>
+		<ul class="nav nav-pills flex-column">
+			<?php
+			foreach ( $authors as $author ) :
+				$author_link = get_permalink( $post ) . 'author/' . $author->slug . '/';
+			?>
+			<li class="nav-item">
+				<a class="nav-link w-100" href="<?php echo $author_link; ?>">
+					<?php echo $author->name; ?>
+				</a>
+			</li>
+			<?php endforeach; ?>
+		</ul>
+	</div>
+	<?php endif; ?>
+<?php
+	return ob_get_clean();
+}

--- a/includes/statements-functions.php
+++ b/includes/statements-functions.php
@@ -234,5 +234,5 @@ function get_statement_filters( $archive_data ) {
 	</div>
 	<?php endif; ?>
 <?php
-	return ob_get_clean();
+	return trim( ob_get_clean() );
 }

--- a/includes/statements-functions.php
+++ b/includes/statements-functions.php
@@ -101,16 +101,7 @@ function statement_year_is_valid( $year ) {
 	if ( ! $year ) return false;
 	$year = intval( $year );
 
-	$archive_data = get_statement_archive_data();
-	if ( ! $archive_data || ! property_exists( $archive_data, 'years' ) ) return false;
-
-	if ( in_array(
-		$year,
-		array_column( $archive_data->years, 'year' )
-	) ) {
-		return true;
-	}
-	return false;
+	return get_statement_year_data( $year ) ? true : false;
 }
 
 
@@ -126,16 +117,7 @@ function statement_year_is_valid( $year ) {
 function statement_author_is_valid( $author ) {
 	if ( ! $author ) return false;
 
-	$archive_data = get_statement_archive_data();
-	if ( ! $archive_data || ! property_exists( $archive_data, 'authors' ) ) return false;
-
-	if ( in_array(
-		$author,
-		array_column( $archive_data->authors, 'slug' )
-	) ) {
-		return true;
-	}
-	return false;
+	return get_statement_author_data( $author ) ? true : false;
 }
 
 
@@ -145,19 +127,19 @@ function statement_author_is_valid( $author ) {
  *
  * @since 3.9.0
  * @author Jo Dickson
- * @return array
+ * @return mixed Object, or null on failure
  */
 function get_statement_archive_data() {
 	$endpoint = get_theme_mod( 'statements_archive_endpoint' );
-	if ( ! $endpoint ) return array();
+	if ( ! $endpoint ) return null;
 
-	$data = array();
+	$data = null;
 
 	$transient = get_transient( 'statements_archive_data' );
 	if ( $transient ) {
 		$data = $transient;
 	} else {
-		$data = main_site_get_remote_response_json( $endpoint, array() );
+		$data = main_site_get_remote_response_json( $endpoint, null );
 		if ( $data ) {
 			// Store transient data for 5 minutes (300 seconds)
 			// TODO allow transient expiration to be configured
@@ -170,43 +152,84 @@ function get_statement_archive_data() {
 
 
 /**
+ * Returns data for the provided year in the statement archive data
+ *
+ * @since 3.9.0
+ * @author Jo Dickson
+ * @param string|int $year Year
+ * @return mixed Object with year data, or null if data for $year isn't available
+ */
+function get_statement_year_data( $year ) {
+	$archive_data = get_statement_archive_data();
+	if ( ! $year || ! $archive_data || ! property_exists( $archive_data, 'years' ) ) return false;
+
+	$year = intval( $year );
+	foreach ( $archive_data->years as $year_data ) {
+		if ( $year === $year_data->year ) {
+			return $year_data;
+			break;
+		}
+	}
+	return null;
+}
+
+
+/**
+ * Returns data for the provided author slug in the statement archive data
+ *
+ * @since 3.9.0
+ * @author Jo Dickson
+ * @param string $author Author slug
+ * @return mixed Object with author data, or null if data for $author isn't available
+ */
+function get_statement_author_data( $author ) {
+	$archive_data = get_statement_archive_data();
+	if ( ! $author || ! $archive_data || ! property_exists( $archive_data, 'authors' ) ) return false;
+
+	foreach ( $archive_data->authors as $author_data ) {
+		if ( $author === $author_data->slug ) {
+			return $author_data;
+			break;
+		}
+	}
+	return null;
+}
+
+
+/**
  * Returns an array of statements, filtered by year/author
  * if query params are set.
  *
  * @since 3.9.0
  * @author Jo Dickson
- * @param array $archive_data Archive data from get_statement_archive_data()
  * @return array
  */
-function get_statement_data( $archive_data ) {
-	if ( ! $archive_data ) return array();
-
-	$endpoint = $archive_data->all->endpoint ?? '';
+function get_statement_data() {
+	$endpoint = '';
 	$q_year   = intval( get_query_var( 'by-year' ) );
 	$q_author = get_query_var( 'tu_author' );
 
 	if ( $q_year ) {
-		foreach ( $archive_data->years as $year ) {
-			if ( $q_year === $year->year ) {
-				$endpoint = $year->endpoint;
-				break;
-			}
+		$year_data = get_statement_year_data( $q_year );
+		if ( $year_data ) {
+			$endpoint = $year_data->endpoint;
 		}
 	} else if ( $q_author ) {
-		foreach ( $archive_data->authors as $author ) {
-			if ( $q_author === $author->slug ) {
-				$endpoint = $author->endpoint;
-				break;
-			}
+		$author_data = get_statement_author_data( $q_author );
+		if ( $author_data ) {
+			$endpoint = $author_data->endpoint;
 		}
+	} else {
+		$archive_data = get_statement_archive_data();
+		$endpoint = $archive_data->all->endpoint ?? '';
 	}
 
 	// If we still don't have a valid endpoint by now,
 	// back out:
-	if ( ! $endpoint ) return array();
+	if ( ! $endpoint ) return null;
 
 	// TODO utilize transients
-	return main_site_get_remote_response_json( $endpoint, array() );
+	return main_site_get_remote_response_json( $endpoint, null );
 }
 
 
@@ -215,13 +238,10 @@ function get_statement_data( $archive_data ) {
  *
  * @since 3.9.0
  * @author Jo Dickson
- * @param array $archive_data Archive data from get_statement_archive_data()
  * @return string
  */
-function get_statements( $archive_data ) {
-	if ( ! $archive_data ) return '';
-
-	$statements = get_statement_data( $archive_data );
+function get_statements() {
+	$statements = get_statement_data();
 	ob_start();
 ?>
 	<?php if ( $statements ) : ?>
@@ -248,28 +268,44 @@ function get_statements( $archive_data ) {
  *
  * @since 3.9.0
  * @author Jo Dickson
- * @param array $archive_data Archive data from get_statement_archive_data()
  * @return string
  */
-function get_statement_filters( $archive_data ) {
+function get_statement_filters() {
 	global $post;
-	if ( ! $post ) return '';
+	$archive_data = get_statement_archive_data();
+	if ( ! $archive_data || ! $post ) return '';
 
-	$years   = $archive_data->years ?? array();
-	$authors = $archive_data->authors ?? array();
+	$years     = $archive_data->years ?? array();
+	$authors   = $archive_data->authors ?? array();
+	$q_year    = intval( get_query_var( 'by-year' ) );
+	$q_author  = get_query_var( 'tu_author' );
+	$permalink = get_permalink( $post );
 
 	ob_start();
 ?>
+	<?php if ( $q_year || $q_author ) : ?>
+	<div class="mb-4 mb-sm-5">
+		<a href="<?php echo $permalink; ?>">
+			<span class="fa fa-chevron-left mr-1" aria-hidden="true"></span>
+			All Statements
+		</a>
+	</div>
+	<?php endif; ?>
+
 	<?php if ( $years ) : ?>
 	<div class="mb-4 mb-sm-5">
 		<h2 class="h6 text-uppercase letter-spacing-3 mb-4">By Year</h2>
 		<ul class="nav nav-pills flex-column">
 			<?php
 			foreach ( $years as $year ) :
-				$year_link = get_permalink( $post ) . 'year/' . $year->year . '/';
+				$year_link = $permalink. 'year/' . $year->year . '/';
+				$year_link_class = 'nav-link w-100';
+				if ( $q_year === $year->year ) {
+					$year_link_class .= ' active';
+				}
 			?>
 			<li class="nav-item">
-				<a class="nav-link w-100" href="<?php echo $year_link; ?>">
+				<a class="<?php echo $year_link_class; ?>" href="<?php echo $year_link; ?>">
 					<?php echo $year->year; ?>
 				</a>
 			</li>
@@ -284,10 +320,14 @@ function get_statement_filters( $archive_data ) {
 		<ul class="nav nav-pills flex-column">
 			<?php
 			foreach ( $authors as $author ) :
-				$author_link = get_permalink( $post ) . 'author/' . $author->slug . '/';
+				$author_link = $permalink . 'author/' . $author->slug . '/';
+				$author_link_class = 'nav-link w-100';
+				if ( $q_author === $author->slug ) {
+					$author_link_class .= ' active';
+				}
 			?>
 			<li class="nav-item">
-				<a class="nav-link w-100" href="<?php echo $author_link; ?>">
+				<a class="<?php echo $author_link_class; ?>" href="<?php echo $author_link; ?>">
 					<?php echo $author->name; ?>
 				</a>
 			</li>
@@ -297,4 +337,48 @@ function get_statement_filters( $archive_data ) {
 	<?php endif; ?>
 <?php
 	return trim( ob_get_clean() );
+}
+
+
+/**
+ * Returns a subhead with extra details about the statement
+ * data being displayed.
+ *
+ * @since 3.9.0
+ * @author Jo Dickson
+ * @param string $unfiltered_fallback Fallback content to return if no filters are present
+ * @return string
+ */
+function get_statement_details( $unfiltered_fallback='' ) {
+	if ( ! has_statement_filters() ) return $unfiltered_fallback;
+
+	$details  = '';
+	$q_year   = intval( get_query_var( 'by-year' ) );
+	$q_author = get_query_var( 'tu_author' );
+
+	if ( $q_year ) {
+		$details = '<h2 class="mb-4">' . $q_year . '</h2>';
+	} else if ( $q_author ) {
+		$author_data = get_statement_author_data( $q_author );
+		if ( $author_data && property_exists( $author_data, 'name' ) ) {
+			$details = '<h2 class="mb-4">' . $author_data->name . '</h2>';
+		}
+	}
+
+	return $details;
+}
+
+
+/**
+ * Returns whether or not the current view has
+ * statement-specific query params set.
+ *
+ * @since 3.9.0
+ * @author Jo Dickson
+ * @return bool
+ */
+function has_statement_filters() {
+	$q_year   = get_query_var( 'by-year' );
+	$q_author = get_query_var( 'tu_author' );
+	return $q_year || $q_author;
 }

--- a/includes/statements-functions.php
+++ b/includes/statements-functions.php
@@ -295,7 +295,7 @@ function get_statement_filters() {
 	</div>
 	<?php endif; ?>
 
-	<?php if ( $years ) : ?>
+	<?php if ( $years && count( $years ) > 1 ) : ?>
 	<div class="mb-4 mb-sm-5">
 		<h2 class="h6 text-uppercase letter-spacing-3 mb-4">By Year</h2>
 		<ul class="nav nav-pills flex-column">
@@ -317,7 +317,7 @@ function get_statement_filters() {
 	</div>
 	<?php endif; ?>
 
-	<?php if ( $authors ) : ?>
+	<?php if ( $authors && count( $authors ) > 1 ) : ?>
 	<div class="mb-4 mb-sm-5">
 		<h2 class="h6 text-uppercase letter-spacing-3 mb-4">Statements Issued By</h2>
 		<ul class="nav nav-pills flex-column">

--- a/includes/statements-functions.php
+++ b/includes/statements-functions.php
@@ -230,7 +230,8 @@ function get_statements() {
 
 	// TODO pagination
 
-	return main_site_get_remote_response_json( $endpoint, null );
+	// Give this request a little extra time to return back
+	return main_site_get_remote_response_json( $endpoint, null, 10 );
 }
 
 

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -101,11 +101,13 @@ function get_attachment_src_by_size( $id, $size ) {
  * @author Jim Barnes
  * @since 3.4.0
  * @param string $url The URL to retrieve
- * @param object The serialized JSON obejct
+ * @param mixed $default A default value to return if the response is invalid
+ * @param int $timeout Timeout for the request, in seconds
+ * @return mixed The serialized JSON object, or $default
  */
-function main_site_get_remote_response_json( $url, $default=null ) {
+function main_site_get_remote_response_json( $url, $default=null, $timeout=5 ) {
 	$args = array(
-		'timeout' => 5
+		'timeout' => $timeout
 	);
 
 	$retval = $default;

--- a/template-statements.php
+++ b/template-statements.php
@@ -9,7 +9,7 @@
 
 <?php
 $statement_details = get_statement_details( get_the_content() );
-$statements        = get_statements();
+$statements        = get_statements_list();
 $filters           = get_statement_filters();
 ?>
 

--- a/template-statements.php
+++ b/template-statements.php
@@ -8,9 +8,9 @@
 <?php get_header(); the_post(); ?>
 
 <?php
-$archive_data = get_statement_archive_data();
-$statements   = get_statements( $archive_data );
-$filters      = get_statement_filters( $archive_data );
+$statement_details = get_statement_details( get_the_content() );
+$statements        = get_statements();
+$filters           = get_statement_filters();
 ?>
 
 <div class="container mt-4 mt-md-5 pb-4 pb-md-5">
@@ -25,7 +25,7 @@ $filters      = get_statement_filters( $archive_data );
 		<?php endif; ?>
 
 		<div class="col">
-			<?php the_content(); ?>
+			<?php echo $statement_details; ?>
 			<?php echo $statements; ?>
 		</div>
 	</div>

--- a/template-statements.php
+++ b/template-statements.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Template Name: Statements
+ * Template Post Type: page
+ */
+?>
+
+<?php get_header(); the_post(); ?>
+
+<?php
+$archive_data = get_statement_archive_data();
+$statements   = get_statements( $archive_data );
+$filters      = get_statement_filters( $archive_data );
+?>
+
+<div class="container mt-4 mt-md-5 pb-4 pb-md-5">
+	<div class="row">
+		<?php if ( $filters ) : ?>
+		<div class="col-lg-4 mb-4 mb-lg-0">
+			<?php echo $filters; ?>
+		</div>
+		<div class="col-auto hidden-md-down pr-lg-4">
+			<hr class="hr-vertical" role="presentation">
+		</div>
+		<?php endif; ?>
+
+		<div class="col">
+			<?php the_content(); ?>
+			<?php echo $statements; ?>
+		</div>
+	</div>
+</div>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
A first pass at implementing a unique page template for displaying an archive of Statements, pulled in from Today.  At this point, the page template is functional, but missing some styling and per_page limits + pagination.

- Added Customizer options for defining the slug path of the page that will use the new template, as well as an option for specifying the URL of the `statements-archive` endpoint on Today, which provides the majority of the data necessary for the template to function
- Added a new "Statements" page template, which uses a bunch of new logic defined in `includes/statement-functions.php` to retrieve and display statement lists and filters.
 
  This template uses some fancy rewrite rules to translate custom query params into pretty permalinks; e.g. `/statements/?tu_author=author-slug` gets rewritten to `/statements/author/author-slug/`.

I will address remaining TODOs in future PR(s).

Depends on https://github.com/UCF/Today-Utilities/pull/37

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This page was requested along with the statement post type additions in Today.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
