### PR TITLE
Statements pagination

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -33,7 +33,8 @@ define( 'THEME_CUSTOMIZER_DEFAULTS', serialize( array(
 	'chartbeat_uid'                     => '2806',
 	'chartbeat_domain'                  => 'ucf.edu',
 	'search_service_url'                => 'https://search.smca.ucf.edu/service.php',
-	'statements_page_path'              => 'statements'
+	'statements_page_path'              => 'statements',
+	'statements_per_page'               => 30
 ) ) );
 
 function __init__() {
@@ -667,7 +668,7 @@ function define_customizer_fields( $wp_customize ) {
 		)
 	);
 
-	// Phonebook
+	// Statements
 	$wp_customize->add_setting(
 		'statements_page_path',
 		array(
@@ -695,6 +696,23 @@ function define_customizer_fields( $wp_customize ) {
 			'type'        => 'text',
 			'label'       => 'Statements Archive API Endpoint',
 			'description' => 'URL to the API endpoint that lists Statement data by year and author.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'statements'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'statements_per_page',
+		array(
+			'default' => get_theme_mod_default( 'statements_per_page' )
+		)
+	);
+
+	$wp_customize->add_control(
+		'statements_per_page',
+		array(
+			'type'        => 'number',
+			'label'       => 'Statements Per Page',
+			'description' => 'The number of Statements that should be listed on the Statements page at a time.',
 			'section'     => THEME_CUSTOMIZER_PREFIX . 'statements'
 		)
 	);

--- a/includes/statements-functions.php
+++ b/includes/statements-functions.php
@@ -455,7 +455,6 @@ class Statements_View {
 		return $details;
 	}
 
-
 	/**
 	 * Returns markup for statement pagination.
 	 *
@@ -465,17 +464,12 @@ class Statements_View {
 	 */
 	public function get_statement_pagination() {
 		$statements_response = $this->statements_response;
-		global $wp;
-		if ( ! $statements_response || ! $wp ) return '';
+		if ( ! $statements_response ) return '';
 
 		$page_num_previous = $this->page_num_previous;
 		$page_num_next     = $this->page_num_next;
 		$has_previous      = $page_num_previous ? true : false;
 		$has_next          = $page_num_next ? true : false;
-
-		// TODO raw ?paged param gets used on the prev/next links;
-		// find some elegant way of making pretty urls instead?
-		$link_base = home_url( $wp->request );
 
 		ob_start();
 	?>
@@ -484,7 +478,7 @@ class Statements_View {
 			<ul class="pagination justify-content-center">
 				<?php if ( $has_previous ) : ?>
 				<li class="page-item">
-					<a class="page-link" href="<?php echo add_query_arg( 'paged', $page_num_previous, $link_base ); ?>">
+					<a class="page-link" href="<?php echo $this->get_statement_pagination_url( $page_num_previous ); ?>">
 						<span class="fa fa-chevron-left mr-1" aria-hidden="true"></span>
 						Newer<span class="sr-only"> Statements</span>
 					</a>
@@ -493,7 +487,7 @@ class Statements_View {
 
 				<?php if ( $has_next ) : ?>
 				<li class="page-item">
-					<a class="page-link" href="<?php echo add_query_arg( 'paged', $page_num_next, $link_base ); ?>">
+					<a class="page-link" href="<?php echo $this->get_statement_pagination_url( $page_num_next ); ?>">
 						Older<span class="sr-only"> Statements</span>
 						<span class="fa fa-chevron-right ml-1" aria-hidden="true"></span>
 					</a>
@@ -504,6 +498,29 @@ class Statements_View {
 		<?php endif; ?>
 	<?php
 		return trim( ob_get_clean() );
+	}
+
+	/**
+	 * Given a desired page number, returns the current view's
+	 * URL with a /page/ path appended to the end.
+	 *
+	 * This function is necessary as WP doesn't provide this type
+	 * of logic out-of-the-box for registered query params.
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @param int $page Page number that a URL should be generated for
+	 * @return string URL for the desired page
+	 */
+	public function get_statement_pagination_url( $page ) {
+		global $wp;
+		if ( ! $wp ) return '';
+
+		$url_parts = explode( '/page/', home_url( $wp->request ) );
+		$url_base  = isset( $url_parts[0] ) ? $url_parts[0] : '';
+		$url       = $page > 1 ? $url_base . '/page/' . $page . '/' : $url_base;
+
+		return $url;
 	}
 
 }

--- a/includes/statements-functions.php
+++ b/includes/statements-functions.php
@@ -34,13 +34,13 @@ class Statements_View {
 			'tu_author' => get_query_var( 'tu_author' ),
 			'paged'     => intval( get_query_var( 'paged' ) ) ?: 1
 		);
+		$this->page_num_current = $this->query_vars['paged'];
 
 		$this->archive_data        = $this->get_archive_data();
 		$this->endpoint_current    = $this->get_queried_endpoint();
 		$this->statements_response = $this->get_statements_response();
 		$this->statements_data     = main_site_get_remote_response_json( $this->statements_response, null );
 
-		$this->page_num_current  = $this->query_vars['paged'];
 		$this->page_num_total    = intval( wp_remote_retrieve_header( $this->statements_response, 'x-wp-totalpages' ) );
 		$this->page_num_previous = $this->page_num_current > 1 ? $this->page_num_current - 1 : 0;
 		$this->page_num_next     = $this->page_num_current < $this->page_num_total ? $this->page_num_current + 1 : 0;

--- a/includes/statements-functions.php
+++ b/includes/statements-functions.php
@@ -17,8 +17,16 @@ function register_statement_rewrite_rules() {
 
 	$statements_pg = get_page_by_path( $statements_pg_path );
 	if ( $statements_pg ) {
-		add_rewrite_rule( '^' . $statements_pg_path . '/year/([0-9]{4})[/]?$', 'index.php?page_id=' . $statements_pg->ID . '&by-year=$matches[1]', 'top' );
-		add_rewrite_rule( '^' . $statements_pg_path . '/author/([a-z0-9_-]+)[/]?$', 'index.php?page_id=' . $statements_pg->ID . '&tu_author=$matches[1]', 'top' );
+		add_rewrite_rule(
+			'^' . $statements_pg_path . '/year/([0-9]{4})(/page/\d+)?[/]?$',
+			'index.php?page_id=' . $statements_pg->ID . '&by-year=$matches[1]&paged=$matches[3]',
+			'top'
+		);
+		add_rewrite_rule(
+			'^' . $statements_pg_path . '/author/([a-z0-9_-]+)(/page/\d+)?[/]?$',
+			'index.php?page_id=' . $statements_pg->ID . '&tu_author=$matches[1]&paged=$matches[3]',
+			'top'
+		);
 	}
 }
 

--- a/includes/statements-functions.php
+++ b/includes/statements-functions.php
@@ -4,528 +4,528 @@
  **/
 
 /**
- * Registers custom rewrite rules to support filtering options
- * on the statements page without straight query params.
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @return void
+ * Class that manages listings of statements and their
+ * filtering options
  */
-function register_statement_rewrite_rules() {
-	$statements_pg_path = untrailingslashit( get_theme_mod_or_default( 'statements_page_path' ) );
-	if ( ! $statements_pg_path ) return;
+class Statements_View {
 
-	$statements_pg = get_page_by_path( $statements_pg_path );
-	if ( $statements_pg ) {
-		add_rewrite_rule(
-			'^' . $statements_pg_path . '/year/([0-9]{4})(/page/(\d+))?[/]?$',
-			'index.php?page_id=' . $statements_pg->ID . '&by-year=$matches[1]&paged=$matches[3]',
-			'top'
+	public $page_path;           // Relative path to the statements page
+	public $page;                // WP_Post object for the statements page
+	public $page_permalink;      // Permalink to the statements page
+	public $query_vars;          // Formatted query vars set on the current view
+	public $archive_data;        // JSON data from the statements-archive API endpoint
+	public $endpoint_current;    // URL to the current page's API endpoint
+	public $statements_response; // Response data from the API endpoint for the current view
+	public $statements_data;     // JSON data from the API endpoint for the current view
+	public $page_num_current;    // The current view's page number
+	public $page_num_total;      // The total number of available pages for this view's set of results
+	public $page_num_previous;   // The page number for the previous page's results
+	public $page_num_next;       // The page number for the next page's results
+
+	function __construct() {
+		$this->page_path      = untrailingslashit( get_theme_mod_or_default( 'statements_page_path' ) );
+		$this->page           = $this->page_path ? get_page_by_path( $this->page_path ) : null;
+		$this->page_permalink = $this->page ? get_permalink( $this->page ) : '';
+	}
+
+	public function setup() {
+		$this->query_vars = array(
+			'by-year'   => intval( get_query_var( 'by-year' ) ),
+			'tu_author' => get_query_var( 'tu_author' ),
+			'paged'     => intval( get_query_var( 'paged' ) ) ?: 1
 		);
-		add_rewrite_rule(
-			'^' . $statements_pg_path . '/author/([a-z0-9_-]+)(/page/(\d+))?[/]?$',
-			'index.php?page_id=' . $statements_pg->ID . '&tu_author=$matches[1]&paged=$matches[3]',
-			'top'
-		);
+
+		$this->archive_data        = $this->get_archive_data();
+		$this->endpoint_current    = $this->get_queried_endpoint();
+		$this->statements_response = $this->get_statements_response();
+		$this->statements_data     = main_site_get_remote_response_json( $this->statements_response, null );
+
+		$this->page_num_current  = $this->query_vars['paged'];
+		$this->page_num_total    = intval( wp_remote_retrieve_header( $this->statements_response, 'x-wp-totalpages' ) );
+		$this->page_num_previous = $this->page_num_current > 1 ? $this->page_num_current - 1 : 0;
+		$this->page_num_next     = $this->page_num_current < $this->page_num_total ? $this->page_num_current + 1 : 0;
 	}
-}
 
-add_action( 'init', 'register_statement_rewrite_rules' );
+	/**
+	 * Returns data for available statement archive endpoints.
+	 * References transient data, if available.
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @return mixed Object, or null on failure
+	 */
+	private function get_archive_data() {
+		$endpoint = get_theme_mod( 'statements_archive_endpoint' );
+		if ( ! $endpoint ) return null;
 
+		$data = null;
 
-/**
- * Registers query vars for the statements page
- * so that WP query var functions recognize them.
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @param array $query_vars Existing public query vars
- * @return array Modified query vars
- */
-function register_statement_query_vars( $query_vars ) {
-	$query_vars[] = 'by-year';
-	$query_vars[] = 'tu_author';
-	return $query_vars;
-}
-
-add_filter( 'query_vars', 'register_statement_query_vars', 10, 1 );
-
-
-/**
- * Handles various redirects for loading filtered statement content
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @return void
- */
-function statement_redirects() {
-	$statements_pg_path = untrailingslashit( get_theme_mod_or_default( 'statements_page_path' ) );
-	if ( ! $statements_pg_path ) return;
-
-	$statements_pg = get_page_by_path( $statements_pg_path );
-	if ( $statements_pg && is_page( $statements_pg->ID ) ) {
-		$should_redirect = false;
-		$year            = intval( get_query_var( 'year' ) );
-		$author          = get_query_var( 'tu_author' );
-
-		// Redirect requests for /{statements_pg_path}/author/,
-		// /{statements_pg_path}/year/, and .../page/X/
-		// with bogus/invalid values
-		//
-		// TODO can pagination validation be done in a way
-		// that doesn't require multiple requests out? :/
-		if (
-			( $year && ! statement_year_is_valid( $year ) )
-			|| ( $author && ! statement_author_is_valid( $author ) )
-			|| ! statement_query_pagination_is_valid()
-		) {
-			$should_redirect = true;
+		$transient = get_transient( 'statements_archive_data' );
+		if ( $transient ) {
+			$data = $transient;
+		} else {
+			$data = main_site_get_remote_response_json( $endpoint, null );
+			if ( $data ) {
+				// Store transient data for 5 minutes (300 seconds)
+				// TODO allow transient expiration to be configured
+				set_transient( 'statements_archive_data', $data, 300 );
+			}
 		}
 
-		if ( $should_redirect ) {
-			// TODO this works for now, but would be nice
-			// if these 404'd instead. This hook doesn't
-			// appear to fire early enough, and the "Statements"
-			// h1 gets printed above the 404 template content.
-			wp_redirect( get_permalink( $statements_pg ) );
-			exit();
-			// global $wp_query;
-			// $wp_query->set_404();
-			// status_header( 404 );
-			// get_template_part( 404 );
-			// exit();
+		return $data;
+	}
+
+	/**
+	 * Returns the URL to the endpoint that provides statement data
+	 * for the query params passed to this request.
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @return string
+	 */
+	private function get_queried_endpoint() {
+		$endpoint = '';
+		$q_year   = $this->query_vars['by-year'];
+		$q_author = $this->query_vars['tu_author'];
+		$q_page   = $this->page_num_current;
+		$per_page = intval( get_theme_mod_or_default( 'statements_per_page' ) );
+
+		if ( $q_year ) {
+			$year_data = $this->get_year_data( $q_year );
+			if ( $year_data ) {
+				$endpoint = $year_data->endpoint;
+			}
+		} else if ( $q_author ) {
+			$author_data = $this->get_author_data( $q_author );
+			if ( $author_data ) {
+				$endpoint = $author_data->endpoint;
+			}
+		} else {
+			$endpoint = $this->archive_data->all->endpoint ?? '';
+		}
+
+		// If we still don't have a valid endpoint by now,
+		// back out:
+		if ( ! $endpoint ) return null;
+
+		// Add per_page param
+		if ( $per_page ) {
+			$endpoint = add_query_arg(
+				'per_page',
+				$per_page,
+				$endpoint
+			);
+		}
+
+		// Add page param
+		if ( $q_page ) {
+			$endpoint = add_query_arg(
+				'page',
+				$q_page,
+				$endpoint
+			);
+		}
+
+		return $endpoint;
+	}
+
+	/**
+	 * Returns an array of request data for the statements endpoint on Today,
+	 * filtered by year/author if query params are set.
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @return mixed Array of response data, or null on failure
+	 */
+	private function get_statements_response() {
+		// Give this request a little extra time to return back
+		return main_site_get_remote_response( $this->endpoint_current, 10 );
+	}
+
+	/**
+	 * Returns whether or not query vars set on the current request
+	 * result in valid pagination.
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @return bool
+	 */
+	public function queried_pagination_is_valid() {
+		return $this->page_num_current <= $this->page_num_total;
+	}
+
+	/**
+	 * Returns whether or not the queried year has
+	 * statement data available.
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @return bool
+	 */
+	public function queried_year_is_valid() {
+		$year = $this->query_vars['by-year'];
+		if ( ! $year ) return true; // allow empty
+
+		return $this->get_year_data( $year ) ? true : false;
+	}
+
+	/**
+	 * Returns whether or not the queried author has
+	 * statement data available.
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @return bool
+	 */
+	public function queried_author_is_valid() {
+		$author = $this->query_vars['tu_author'];
+		if ( ! $author ) return true; // allow empty
+
+		return $this->get_author_data( $author ) ? true : false;
+	}
+
+	/**
+	 * Returns data for the provided year in the statement archive data
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @param string|int $year Year
+	 * @return mixed Object with year data, or null if data for $year isn't available
+	 */
+	public function get_year_data( $year ) {
+		$archive_data = $this->archive_data;
+		if ( ! $year || ! $archive_data || ! property_exists( $archive_data, 'years' ) ) return false;
+
+		$year = intval( $year );
+		foreach ( $archive_data->years as $year_data ) {
+			if ( $year === $year_data->year ) {
+				return $year_data;
+				break;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns data for the provided author slug in the statement archive data
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @param string $author Author slug
+	 * @return mixed Object with author data, or null if data for $author isn't available
+	 */
+	public function get_author_data( $author ) {
+		$archive_data = $this->archive_data;
+		if ( ! $author || ! $archive_data || ! property_exists( $archive_data, 'authors' ) ) return false;
+
+		foreach ( $archive_data->authors as $author_data ) {
+			if ( $author === $author_data->slug ) {
+				return $author_data;
+				break;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns whether or not the current view has
+	 * statement-specific query params set.
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @return bool
+	 */
+	function has_filters() {
+		return $this->query_vars['by-year'] || $this->query_vars['tu_author'];
+	}
+
+	/**
+	 * Registers custom rewrite rules to support filtering options
+	 * on the statements page without straight query params.
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @return void
+	 */
+	public function register_rewrite_rules() {
+		$statements_pg_path = $this->page_path;
+		$statements_pg      = $this->page;
+
+		if ( $statements_pg && $statements_pg_path ) {
+			add_rewrite_rule(
+				'^' . $statements_pg_path . '/year/([0-9]{4})(/page/(\d+))?[/]?$',
+				'index.php?page_id=' . $statements_pg->ID . '&by-year=$matches[1]&paged=$matches[3]',
+				'top'
+			);
+			add_rewrite_rule(
+				'^' . $statements_pg_path . '/author/([a-z0-9_-]+)(/page/(\d+))?[/]?$',
+				'index.php?page_id=' . $statements_pg->ID . '&tu_author=$matches[1]&paged=$matches[3]',
+				'top'
+			);
 		}
 	}
-}
 
-add_action( 'template_redirect', 'statement_redirects', 999 );
-
-
-/**
- * Returns whether or not the provided year has
- * statement data available.
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @param int|string $year A year
- * @return bool
- */
-function statement_year_is_valid( $year ) {
-	if ( ! $year ) return false;
-	$year = intval( $year );
-
-	return get_statement_year_data( $year ) ? true : false;
-}
-
-
-/**
- * Returns whether or not the provided author has
- * statement data available.
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @param string $author An author slug
- * @return bool
- */
-function statement_author_is_valid( $author ) {
-	if ( ! $author ) return false;
-
-	return get_statement_author_data( $author ) ? true : false;
-}
-
-
-/**
- * Returns whether or not query vars set on the current request
- * result in valid pagination.
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @return bool
- */
-function statement_query_pagination_is_valid() {
-	$endpoint = get_queried_statements_endpoint();
-	if ( ! $endpoint ) return false;
-
-	$response_headers = wp_get_http_headers( $endpoint );
-	if ( ! $response_headers ) return false;
-
-	$current_page = get_statements_current_page();
-	if (
-		! isset( $response_headers['x-wp-totalpages'] )
-		|| (
-			isset( $response_headers['x-wp-totalpages'] )
-			&& $current_page > intval( $response_headers['x-wp-totalpages'] )
-		)
-	) {
-		return false;
+	/**
+	 * Registers query vars for the statements page
+	 * so that WP query var functions recognize them.
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @param array $query_vars Existing public query vars
+	 * @return array Modified query vars
+	 */
+	public function register_query_vars( $query_vars ) {
+		$query_vars[] = 'by-year';
+		$query_vars[] = 'tu_author';
+		return $query_vars;
 	}
 
-	return true;
-}
+	/**
+	 * Handles various redirects for loading filtered statement content
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @return void
+	 */
+	public function statement_redirects() {
+		$statements_pg = $this->page;
 
+		if ( $statements_pg && is_page( $statements_pg->ID ) ) {
+			$should_redirect = false;
 
-/**
- * Returns data for available statement archive endpoints.
- * References transient data, if available.
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @return mixed Object, or null on failure
- */
-function get_statement_archive_data() {
-	$endpoint = get_theme_mod( 'statements_archive_endpoint' );
-	if ( ! $endpoint ) return null;
+			// Redirect requests for /{statements_pg_path}/author/,
+			// /{statements_pg_path}/year/, and .../page/X/
+			// with bogus/invalid values
+			if (
+				! $this->queried_year_is_valid()
+				|| ! $this->queried_author_is_valid()
+				|| ! $this->queried_pagination_is_valid()
+			) {
+				$should_redirect = true;
+			}
 
-	$data = null;
-
-	$transient = get_transient( 'statements_archive_data' );
-	if ( $transient ) {
-		$data = $transient;
-	} else {
-		$data = main_site_get_remote_response_json( $endpoint, null );
-		if ( $data ) {
-			// Store transient data for 5 minutes (300 seconds)
-			// TODO allow transient expiration to be configured
-			set_transient( 'statements_archive_data', $data, 300 );
+			if ( $should_redirect ) {
+				// TODO this works for now, but would be nice
+				// if these 404'd instead. This hook doesn't
+				// appear to fire early enough, and the "Statements"
+				// h1 gets printed above the 404 template content.
+				wp_redirect( $this->page_permalink );
+				exit();
+				// global $wp_query;
+				// $wp_query->set_404();
+				// status_header( 404 );
+				// get_template_part( 404 );
+				// exit();
+			}
 		}
 	}
 
-	return $data;
-}
+	/**
+ 	 * Returns markup for a list of statements.
+	 * TODO styling
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @return string
+	 */
+	public function get_statements_list() {
+		$statements = $this->statements_data;
 
-
-/**
- * Returns data for the provided year in the statement archive data
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @param string|int $year Year
- * @return mixed Object with year data, or null if data for $year isn't available
- */
-function get_statement_year_data( $year ) {
-	$archive_data = get_statement_archive_data();
-	if ( ! $year || ! $archive_data || ! property_exists( $archive_data, 'years' ) ) return false;
-
-	$year = intval( $year );
-	foreach ( $archive_data->years as $year_data ) {
-		if ( $year === $year_data->year ) {
-			return $year_data;
-			break;
-		}
-	}
-	return null;
-}
-
-
-/**
- * Returns data for the provided author slug in the statement archive data
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @param string $author Author slug
- * @return mixed Object with author data, or null if data for $author isn't available
- */
-function get_statement_author_data( $author ) {
-	$archive_data = get_statement_archive_data();
-	if ( ! $author || ! $archive_data || ! property_exists( $archive_data, 'authors' ) ) return false;
-
-	foreach ( $archive_data->authors as $author_data ) {
-		if ( $author === $author_data->slug ) {
-			return $author_data;
-			break;
-		}
-	}
-	return null;
-}
-
-
-/**
- * Returns the URL to the endpoint that provides statement data
- * for the query params passed to this request.
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @return string
- */
-function get_queried_statements_endpoint() {
-	$endpoint = '';
-	$q_year   = intval( get_query_var( 'by-year' ) );
-	$q_author = get_query_var( 'tu_author' );
-	$q_page   = get_statements_current_page();
-	$per_page = intval( get_theme_mod_or_default( 'statements_per_page' ) );
-
-	if ( $q_year ) {
-		$year_data = get_statement_year_data( $q_year );
-		if ( $year_data ) {
-			$endpoint = $year_data->endpoint;
-		}
-	} else if ( $q_author ) {
-		$author_data = get_statement_author_data( $q_author );
-		if ( $author_data ) {
-			$endpoint = $author_data->endpoint;
-		}
-	} else {
-		$archive_data = get_statement_archive_data();
-		$endpoint = $archive_data->all->endpoint ?? '';
+		ob_start();
+	?>
+		<?php if ( $statements ) : ?>
+		<ul>
+			<?php foreach ( $statements as $statement ) : ?>
+			<li>
+				<a href="<?php echo $statement->link; ?>">
+					<?php echo $statement->title->rendered; ?>
+				</a>
+			</li>
+			<?php endforeach; ?>
+		</ul>
+		<?php else : ?>
+		<p>No statements found.</p>
+		<?php endif; ?>
+	<?php
+		return trim( ob_get_clean() );
 	}
 
-	// If we still don't have a valid endpoint by now,
-	// back out:
-	if ( ! $endpoint ) return null;
 
-	// Add per_page param
-	if ( $per_page ) {
-		$endpoint = add_query_arg(
-			'per_page',
-			$per_page,
-			$endpoint
-		);
-	}
+	/**
+	 * Returns markup for filtering statements.
+	 * TODO add expand/collapse at -xs-md
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @return string
+	 */
+	public function get_statement_filters() {
+		$archive_data = $this->archive_data;
+		if ( ! $archive_data ) return '';
 
-	// Add page param
-	if ( $q_page ) {
-		$endpoint = add_query_arg(
-			'page',
-			$q_page,
-			$endpoint
-		);
-	}
+		$years     = $archive_data->years ?? array();
+		$authors   = $archive_data->authors ?? array();
+		$q_year    = $this->query_vars['by-year'];
+		$q_author  = $this->query_vars['tu_author'];
+		$permalink = $this->page_permalink;
 
-	return $endpoint;
-}
-
-
-/**
- * Returns an array of request data for the statements endpoint on Today,
- * filtered by year/author if query params are set.
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @return mixed Array of response data, or null on failure
- */
-function get_statements_response() {
-	$endpoint = get_queried_statements_endpoint();
-
-	// Give this request a little extra time to return back
-	return main_site_get_remote_response( $endpoint, 10 );
-}
-
-
-/**
- * Returns markup for a list of statements.
- * TODO styling
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @param array $statements_response Response data from get_statements_response()
- * @return string
- */
-function get_statements_list( $statements_response ) {
-	$statements_response = $statements_response ?: get_statements_response();
-	$statements          = main_site_get_remote_response_json( $statements_response, null );
-
-	ob_start();
-?>
-	<?php if ( $statements ) : ?>
-	<ul>
-		<?php foreach ( $statements as $statement ) : ?>
-		<li>
-			<a href="<?php echo $statement->link; ?>">
-				<?php echo $statement->title->rendered; ?>
+		ob_start();
+	?>
+		<?php if ( $q_year || $q_author ) : ?>
+		<div class="mb-4 mb-sm-5">
+			<a href="<?php echo $permalink; ?>">
+				<span class="fa fa-chevron-left mr-1" aria-hidden="true"></span>
+				All Statements
 			</a>
-		</li>
-		<?php endforeach; ?>
-	</ul>
-	<?php else : ?>
-	<p>No statements found.</p>
-	<?php endif; ?>
-<?php
-	return trim( ob_get_clean() );
-}
+		</div>
+		<?php endif; ?>
 
+		<?php if ( $years && count( $years ) > 1 ) : ?>
+		<div class="mb-4 mb-sm-5">
+			<h2 class="h6 text-uppercase letter-spacing-3 mb-4">By Year</h2>
+			<ul class="nav nav-pills flex-column">
+				<?php
+				foreach ( $years as $year ) :
+					$year_link = $permalink. 'year/' . $year->year . '/';
+					$year_link_class = 'nav-link w-100';
+					if ( $q_year === $year->year ) {
+						$year_link_class .= ' active';
+					}
+				?>
+				<li class="nav-item">
+					<a class="<?php echo $year_link_class; ?>" href="<?php echo $year_link; ?>">
+						<?php echo $year->year; ?>
+					</a>
+				</li>
+				<?php endforeach; ?>
+			</ul>
+		</div>
+		<?php endif; ?>
 
-/**
- * Returns markup for filtering statements.
- * TODO add expand/collapse at -xs-md
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @return string
- */
-function get_statement_filters() {
-	global $post;
-	$archive_data = get_statement_archive_data();
-	if ( ! $archive_data || ! $post ) return '';
-
-	$years     = $archive_data->years ?? array();
-	$authors   = $archive_data->authors ?? array();
-	$q_year    = intval( get_query_var( 'by-year' ) );
-	$q_author  = get_query_var( 'tu_author' );
-	$permalink = get_permalink( $post );
-
-	ob_start();
-?>
-	<?php if ( $q_year || $q_author ) : ?>
-	<div class="mb-4 mb-sm-5">
-		<a href="<?php echo $permalink; ?>">
-			<span class="fa fa-chevron-left mr-1" aria-hidden="true"></span>
-			All Statements
-		</a>
-	</div>
-	<?php endif; ?>
-
-	<?php if ( $years && count( $years ) > 1 ) : ?>
-	<div class="mb-4 mb-sm-5">
-		<h2 class="h6 text-uppercase letter-spacing-3 mb-4">By Year</h2>
-		<ul class="nav nav-pills flex-column">
-			<?php
-			foreach ( $years as $year ) :
-				$year_link = $permalink. 'year/' . $year->year . '/';
-				$year_link_class = 'nav-link w-100';
-				if ( $q_year === $year->year ) {
-					$year_link_class .= ' active';
-				}
-			?>
-			<li class="nav-item">
-				<a class="<?php echo $year_link_class; ?>" href="<?php echo $year_link; ?>">
-					<?php echo $year->year; ?>
-				</a>
-			</li>
-			<?php endforeach; ?>
-		</ul>
-	</div>
-	<?php endif; ?>
-
-	<?php if ( $authors && count( $authors ) > 1 ) : ?>
-	<div class="mb-4 mb-sm-5">
-		<h2 class="h6 text-uppercase letter-spacing-3 mb-4">Statements Issued By</h2>
-		<ul class="nav nav-pills flex-column">
-			<?php
-			foreach ( $authors as $author ) :
-				$author_link = $permalink . 'author/' . $author->slug . '/';
-				$author_link_class = 'nav-link w-100';
-				if ( $q_author === $author->slug ) {
-					$author_link_class .= ' active';
-				}
-			?>
-			<li class="nav-item">
-				<a class="<?php echo $author_link_class; ?>" href="<?php echo $author_link; ?>">
-					<?php echo $author->name; ?>
-				</a>
-			</li>
-			<?php endforeach; ?>
-		</ul>
-	</div>
-	<?php endif; ?>
-<?php
-	return trim( ob_get_clean() );
-}
-
-
-/**
- * Returns a subhead with extra details about the statement
- * data being displayed.
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @param string $unfiltered_fallback Fallback content to return if no filters are present
- * @return string
- */
-function get_statement_details( $unfiltered_fallback='' ) {
-	if ( ! has_statement_filters() ) return $unfiltered_fallback;
-
-	$details  = '';
-	$q_year   = intval( get_query_var( 'by-year' ) );
-	$q_author = get_query_var( 'tu_author' );
-
-	if ( $q_year ) {
-		$details = '<h2 class="mb-4">' . $q_year . '</h2>';
-	} else if ( $q_author ) {
-		$author_data = get_statement_author_data( $q_author );
-		if ( $author_data && property_exists( $author_data, 'name' ) ) {
-			$details = '<h2 class="mb-4">' . $author_data->name . '</h2>';
-		}
+		<?php if ( $authors && count( $authors ) > 1 ) : ?>
+		<div class="mb-4 mb-sm-5">
+			<h2 class="h6 text-uppercase letter-spacing-3 mb-4">Statements Issued By</h2>
+			<ul class="nav nav-pills flex-column">
+				<?php
+				foreach ( $authors as $author ) :
+					$author_link = $permalink . 'author/' . $author->slug . '/';
+					$author_link_class = 'nav-link w-100';
+					if ( $q_author === $author->slug ) {
+						$author_link_class .= ' active';
+					}
+				?>
+				<li class="nav-item">
+					<a class="<?php echo $author_link_class; ?>" href="<?php echo $author_link; ?>">
+						<?php echo $author->name; ?>
+					</a>
+				</li>
+				<?php endforeach; ?>
+			</ul>
+		</div>
+		<?php endif; ?>
+	<?php
+		return trim( ob_get_clean() );
 	}
 
-	return $details;
+	/**
+	 * Returns a subhead with extra details about the statement
+	 * data being displayed.
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @param string $unfiltered_fallback Fallback content to return if no filters are present
+	 * @return string
+	 */
+	public function get_statements_details( $unfiltered_fallback='' ) {
+		if ( ! $this->has_filters() ) return $unfiltered_fallback;
+
+		$details  = '';
+		$q_year   = $this->query_vars['by-year'];
+		$q_author = $this->query_vars['tu_author'];
+
+		if ( $q_year ) {
+			$details = '<h2 class="mb-4">' . $q_year . '</h2>';
+		} else if ( $q_author ) {
+			$author_data = $this->get_author_data( $q_author );
+			if ( $author_data && property_exists( $author_data, 'name' ) ) {
+				$details = '<h2 class="mb-4">' . $author_data->name . '</h2>';
+			}
+		}
+
+		return $details;
+	}
+
+
+	/**
+	 * Returns markup for statement pagination.
+	 *
+	 * @since 3.9.0
+	 * @author Jo Dickson
+	 * @return string
+	 */
+	public function get_statement_pagination() {
+		$statements_response = $this->statements_response;
+		global $wp;
+		if ( ! $statements_response || ! $wp ) return '';
+
+		$page_num_previous = $this->page_num_previous;
+		$page_num_next     = $this->page_num_next;
+		$has_previous      = $page_num_previous ? true : false;
+		$has_next          = $page_num_next ? true : false;
+
+		// TODO raw ?paged param gets used on the prev/next links;
+		// find some elegant way of making pretty urls instead?
+		$link_base = home_url( $wp->request );
+
+		ob_start();
+	?>
+		<?php if ( $has_previous || $has_next ) : ?>
+		<nav aria-label="Statements Pagination">
+			<ul class="pagination justify-content-center">
+				<?php if ( $has_previous ) : ?>
+				<li class="page-item">
+					<a class="page-link" href="<?php echo add_query_arg( 'paged', $page_num_previous, $link_base ); ?>">
+						<span class="fa fa-chevron-left mr-1" aria-hidden="true"></span>
+						Newer<span class="sr-only"> Statements</span>
+					</a>
+				</li>
+				<?php endif; ?>
+
+				<?php if ( $has_next ) : ?>
+				<li class="page-item">
+					<a class="page-link" href="<?php echo add_query_arg( 'paged', $page_num_next, $link_base ); ?>">
+						Older<span class="sr-only"> Statements</span>
+						<span class="fa fa-chevron-right ml-1" aria-hidden="true"></span>
+					</a>
+				</li>
+				<?php endif; ?>
+			</ul>
+		</nav>
+		<?php endif; ?>
+	<?php
+		return trim( ob_get_clean() );
+	}
+
 }
 
 
-/**
- * Returns markup for statement pagination.
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @return string
- */
-function get_statement_pagination( $statements_response ) {
-	$statements_response = $statements_response ?: get_statements_response();
-	global $wp;
-	global $post;
-	if ( ! $statements_response || ! $post || ! $wp ) return '';
+$statements_view = new Statements_View();
 
-	$statements_pages = intval( $statements_response['headers']['x-wp-totalpages'] );
-	$current_page     = get_statements_current_page();
+add_action( 'init', array( $statements_view, 'register_rewrite_rules' ) );
+add_filter( 'query_vars', array( $statements_view, 'register_query_vars' ), 10, 1 );
 
-	$has_prev = $current_page !== 1;
-	$has_next = $current_page < $statements_pages;
+// Only finish initializing view stuff if we're on the Statements page:
+add_action( 'wp', function() use( $statements_view ) {
+	if ( is_page( $statements_view->page->ID ) ) {
+		$statements_view->setup();
 
-	// TODO raw ?paged param gets used on the prev/next links;
-	// find some elegant way of making pretty urls instead?
-	$link_base = home_url( $wp->request );
+		add_action( 'template_redirect', function() use( $statements_view ) {
+			$statements_view->statement_redirects();
+		}, 999 );
 
-	ob_start();
-?>
-	<?php if ( $has_prev || $has_next ) : ?>
-	<nav aria-label="Statements Pagination">
-		<ul class="pagination justify-content-center">
-			<?php if ( $has_prev ) : ?>
-			<li class="page-item">
-				<a class="page-link" href="<?php echo add_query_arg( 'paged', $current_page - 1, $link_base ); ?>">
-					<span class="fa fa-chevron-left mr-1" aria-hidden="true"></span>
-					Newer<span class="sr-only"> Statements</span>
-				</a>
-			</li>
-			<?php endif; ?>
-
-			<?php if ( $has_next ) : ?>
-			<li class="page-item">
-				<a class="page-link" href="<?php echo add_query_arg( 'paged', $current_page + 1, $link_base ); ?>">
-					Older<span class="sr-only"> Statements</span>
-					<span class="fa fa-chevron-right ml-1" aria-hidden="true"></span>
-				</a>
-			</li>
-			<?php endif; ?>
-		</ul>
-	</nav>
-	<?php endif; ?>
-<?php
-	return trim( ob_get_clean() );
-}
-
-
-/**
- * Returns whether or not the current view has
- * statement-specific query params set.
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @return bool
- */
-function has_statement_filters() {
-	$q_year   = get_query_var( 'by-year' );
-	$q_author = get_query_var( 'tu_author' );
-	return $q_year || $q_author;
-}
-
-
-/**
- * Returns the current page number for the queried results page.
- *
- * @since 3.9.0
- * @author Jo Dickson
- * @return int
- */
-function get_statements_current_page() {
-	return intval( get_query_var( 'paged' ) ?: 1 );
-}
+		// TODO there is probably a better way of doing this, but whatever
+		add_filter( 'mainsite_statements_view', function() use( $statements_view ) {
+			return $statements_view;
+		} );
+	}
+} );

--- a/includes/statements-functions.php
+++ b/includes/statements-functions.php
@@ -68,8 +68,10 @@ function statement_redirects() {
 		$year            = get_query_var( 'by-year' );
 		$author          = get_query_var( 'tu_author' );
 
-		// Redirect requests for /{statements_pg_path}/author/ and
-		// /{statements_pg_path}/year/ with bogus/invalid values
+		// Redirect requests for /{statements_pg_path}/author/,
+		// /{statements_pg_path}/year/, and .../page/X/
+		// with bogus/invalid values
+		// TODO handle bogus pagination
 		if (
 			( $year && ! statement_year_is_valid( $year ) )
 			|| ( $author && ! statement_author_is_valid( $author ) )
@@ -205,8 +207,8 @@ function get_statement_author_data( $author ) {
 
 
 /**
- * Returns an array of statements, filtered by year/author
- * if query params are set.
+ * Returns an array of request data for the statements endpoint on Today,
+ * filtered by year/author if query params are set.
  *
  * @since 3.9.0
  * @author Jo Dickson
@@ -236,10 +238,11 @@ function get_statements() {
 	// back out:
 	if ( ! $endpoint ) return null;
 
+	// TODO implement per_page
 	// TODO pagination
 
 	// Give this request a little extra time to return back
-	return main_site_get_remote_response_json( $endpoint, null, 10 );
+	return main_site_get_remote_response( $endpoint, 10 );
 }
 
 
@@ -253,7 +256,19 @@ function get_statements() {
  * @return string
  */
 function get_statements_list() {
-	$statements = get_statements();
+	$statements_response = get_statements();
+	$statements          = main_site_get_remote_response_json( $statements_response, null );
+	$statements_total    = 0;
+	$statements_pages    = 1;
+
+	if ( $statements ) {
+		$statements_total = intval( $statements_response['headers']['x-wp-total'] );
+		$statements_pages = intval( $statements_response['headers']['x-wp-totalpages'] );
+	}
+
+	// var_dump($statements_total);
+	// var_dump($statements_pages);
+
 	ob_start();
 ?>
 	<?php if ( $statements ) : ?>

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -96,25 +96,50 @@ function get_attachment_src_by_size( $id, $size ) {
 
 
 /**
+ * Helper function for retrieving a remote response
+ *
+ * @author Jo Dickson
+ * @since 3.9.0
+ * @param mixed $remote The URL to retrieve, or a response array from wp_remote_get()
+ * @param int $timeout Timeout for the request, in seconds
+ * @return mixed Array of response data, or null on failure/bad response
+ */
+function main_site_get_remote_response( $url, $timeout=5 ) {
+	$retval = null;
+	if ( ! $url || ! is_string( $url ) ) return $retval;
+
+	$args = array(
+		'timeout' => $timeout
+	);
+	$response = wp_remote_get( $url, $args );
+
+	if ( is_array( $response ) && wp_remote_retrieve_response_code( $response ) < 400 ) {
+		$retval = $response;
+	}
+
+	return $retval;
+}
+
+
+/**
  * Helper function for getting remote json
  *
  * @author Jim Barnes
  * @since 3.4.0
- * @param string $url The URL to retrieve
+ * @param mixed $remote The URL to retrieve, or a response array from wp_remote_get()
  * @param mixed $default A default value to return if the response is invalid
  * @param int $timeout Timeout for the request, in seconds
  * @return mixed The serialized JSON object, or $default
  */
-function main_site_get_remote_response_json( $url, $default=null, $timeout=5 ) {
-	$args = array(
-		'timeout' => $timeout
-	);
+function main_site_get_remote_response_json( $remote, $default=null, $timeout=5 ) {
+	$retval   = $default;
+	$response = is_array( $remote ) ? $remote : main_site_get_remote_response( $remote, $timeout );
 
-	$retval = $default;
-	$response = wp_remote_get( $url, $args );
-
-	if ( is_array( $response ) && wp_remote_retrieve_response_code( $response ) < 400 ) {
-		$retval = json_decode( wp_remote_retrieve_body( $response ) );
+	if ( $response ) {
+		$json = json_decode( wp_remote_retrieve_body( $response ) );
+		if ( $json ) {
+			$retval = $json;
+		}
 	}
 
 	return $retval;

--- a/template-statements.php
+++ b/template-statements.php
@@ -8,11 +8,11 @@
 <?php get_header(); the_post(); ?>
 
 <?php
-$statements_response = get_statements_response();
-$statement_details   = get_statement_details( get_the_content() );
-$statements          = get_statements_list( $statements_response );
-$filters             = get_statement_filters();
-$pagination          = get_statement_pagination( $statements_response );
+$statements_view     = apply_filters( 'mainsite_statements_view', null );
+$statement_details   = $statements_view->get_statements_details( get_the_content() ) ?? get_the_content();
+$statements          = $statements_view->get_statements_list() ?? '<p>No statements available.</p>';
+$filters             = $statements_view->get_statement_filters() ?? '';
+$pagination          = $statements_view->get_statement_pagination() ?? '';
 ?>
 
 <div class="container mt-4 mt-md-5 pb-4 pb-md-5">

--- a/template-statements.php
+++ b/template-statements.php
@@ -8,9 +8,11 @@
 <?php get_header(); the_post(); ?>
 
 <?php
-$statement_details = get_statement_details( get_the_content() );
-$statements        = get_statements_list();
-$filters           = get_statement_filters();
+$statements_response = get_statements_response();
+$statement_details   = get_statement_details( get_the_content() );
+$statements          = get_statements_list( $statements_response );
+$filters             = get_statement_filters();
+$pagination          = get_statement_pagination( $statements_response );
 ?>
 
 <div class="container mt-4 mt-md-5 pb-4 pb-md-5">
@@ -27,6 +29,7 @@ $filters           = get_statement_filters();
 		<div class="col">
 			<?php echo $statement_details; ?>
 			<?php echo $statements; ?>
+			<?php echo $pagination; ?>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Adds functioning pagination to the statements page.  To do this in a sane way, I ended up refactoring the existing logic into a new class, `Statements_View`, which helps store fetched API data and eliminates the need for data juggling between various functions.

Property setting is split between the class constructor and a custom `setup()` method to avoid calling a bunch of logic and making external API requests on pages that aren't the Statements page.  Additionally, rewrite rules and query vars must be registered before `get_query_var()` can work properly; hence the remaining setup logic in the `wp` hook at the bottom of that file.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The WP REST API won't return more than 100 results at a time, so we must implement pagination to be able to list older statement posts.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
