### PR TITLE
Updated invalid statements views to 404 instead of redirect

### DIFF
--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -87,6 +87,8 @@ function get_header_videos( $obj ) {
  * Returns title text for use in the page header.
  **/
  function get_header_title( $obj ) {
+	if ( is_404() ) return '';
+
 	$field_id = get_object_field_id( $obj );
 	$title = '';
 

--- a/includes/statements-functions.php
+++ b/includes/statements-functions.php
@@ -305,17 +305,11 @@ class Statements_View {
 			}
 
 			if ( $should_redirect ) {
-				// TODO this works for now, but would be nice
-				// if these 404'd instead. This hook doesn't
-				// appear to fire early enough, and the "Statements"
-				// h1 gets printed above the 404 template content.
-				wp_redirect( $this->page_permalink );
+				global $wp_query;
+				$wp_query->set_404();
+				status_header( 404 );
+				get_template_part( 404 );
 				exit();
-				// global $wp_query;
-				// $wp_query->set_404();
-				// status_header( 404 );
-				// get_template_part( 404 );
-				// exit();
 			}
 		}
 	}
@@ -538,7 +532,7 @@ add_action( 'wp', function() use( $statements_view ) {
 
 		add_action( 'template_redirect', function() use( $statements_view ) {
 			$statements_view->statement_redirects();
-		}, 999 );
+		}, 99 );
 
 		// TODO there is probably a better way of doing this, but whatever
 		add_filter( 'mainsite_statements_view', function() use( $statements_view ) {


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.  Also fixed `get_header_title()` to accommodate this change (and not display the Statements page title above the 404 template content).

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For more consistency with how invalid results for vanilla WP archive views would behave.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
