### PR TITLE
Recreated faculty fields branch

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -2300,6 +2300,355 @@
         "description": ""
     },
     {
+        "key": "group_60afe6ef8a553",
+        "title": "Faculty Fields",
+        "fields": [
+            {
+                "key": "field_60afe82b124b5",
+                "label": "Organizational Information",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_60afe850124b6",
+                "label": "College",
+                "name": "person_college",
+                "type": "taxonomy",
+                "instructions": "Choose the college the faculty member is associate with.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "taxonomy": "colleges",
+                "field_type": "checkbox",
+                "add_term": 0,
+                "save_terms": 0,
+                "load_terms": 0,
+                "return_format": "object",
+                "multiple": 0,
+                "allow_null": 0
+            },
+            {
+                "key": "field_60afe880124b7",
+                "label": "Department",
+                "name": "person_department",
+                "type": "text",
+                "instructions": "Enter the department of the faculty member.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            },
+            {
+                "key": "field_60b1044c625b5",
+                "label": "ORCID ID",
+                "name": "person_orcid_id",
+                "type": "text",
+                "instructions": "Unique ID out of the ORCID system that identifies a faculty member. Used for import purposes only.",
+                "required": 1,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            },
+            {
+                "key": "field_60afe6f4124ac",
+                "label": "Education",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_60afe706124ad",
+                "label": "Degrees",
+                "name": "person_degrees",
+                "type": "repeater",
+                "instructions": "Enter the degree, institution and years when each degree was received.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "collapsed": "",
+                "min": 0,
+                "max": 0,
+                "layout": "table",
+                "button_label": "",
+                "sub_fields": [
+                    {
+                        "key": "field_60afeac23c617",
+                        "label": "Insitution Name",
+                        "name": "insitution_name",
+                        "type": "text",
+                        "instructions": "",
+                        "required": 1,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    },
+                    {
+                        "key": "field_60afeb303c61b",
+                        "label": "Role Name",
+                        "name": "role_name",
+                        "type": "text",
+                        "instructions": "Generally this is the name of the degree conferred.",
+                        "required": 1,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    },
+                    {
+                        "key": "field_60afeae23c618",
+                        "label": "Start Date",
+                        "name": "start_date",
+                        "type": "date_picker",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "display_format": "F j, Y",
+                        "return_format": "m\/d\/Y",
+                        "first_day": 0
+                    },
+                    {
+                        "key": "field_60afeb073c619",
+                        "label": "End Date",
+                        "name": "end_date",
+                        "type": "date_picker",
+                        "instructions": "",
+                        "required": 1,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "display_format": "F j, Y",
+                        "return_format": "m\/d\/Y",
+                        "first_day": 0
+                    },
+                    {
+                        "key": "field_60afeb233c61a",
+                        "label": "Department Name",
+                        "name": "department_name",
+                        "type": "text",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    },
+                    {
+                        "key": "field_60afeb533c61c",
+                        "label": "Education Put Code",
+                        "name": "education_put_code",
+                        "type": "number",
+                        "instructions": "The number from ORCID which identifies the record. Used for import purposes.",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "min": "",
+                        "max": "",
+                        "step": ""
+                    }
+                ]
+            },
+            {
+                "key": "field_60afe789124b0",
+                "label": "Research",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_60afe79a124b1",
+                "label": "Books",
+                "name": "person_books",
+                "type": "repeater",
+                "instructions": "Enter a citation for each book.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "collapsed": "field_60afe7ae124b2",
+                "min": 0,
+                "max": 0,
+                "layout": "row",
+                "button_label": "Add Book",
+                "sub_fields": [
+                    {
+                        "key": "field_60afe7ae124b2",
+                        "label": "Book Citation",
+                        "name": "book_citation",
+                        "type": "text",
+                        "instructions": "",
+                        "required": 1,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    }
+                ]
+            },
+            {
+                "key": "field_60afe7cb124b3",
+                "label": "Articles",
+                "name": "person_articles",
+                "type": "repeater",
+                "instructions": "Enter a citation for each article published.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "collapsed": "field_60afe7e1124b4",
+                "min": 0,
+                "max": 0,
+                "layout": "row",
+                "button_label": "Add Article",
+                "sub_fields": [
+                    {
+                        "key": "field_60afe7e1124b4",
+                        "label": "Article Citation",
+                        "name": "article_citation",
+                        "type": "text",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "maxlength": ""
+                    }
+                ]
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "person"
+                },
+                {
+                    "param": "post_template",
+                    "operator": "==",
+                    "value": "template-faculty.php"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": true,
+        "description": ""
+    },
+    {
         "key": "group_58f7a73f5fecc",
         "title": "Page Header Fields",
         "fields": [
@@ -2687,6 +3036,104 @@
                     "param": "taxonomy",
                     "operator": "==",
                     "value": "colleges"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": true,
+        "description": ""
+    },
+    {
+        "key": "group_60afe4968b8d2",
+        "title": "Person Fields",
+        "fields": [
+            {
+                "key": "field_60afe4f815aac",
+                "label": "Title",
+                "name": "person_title",
+                "type": "text",
+                "instructions": "The title of the person",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            },
+            {
+                "key": "field_60afe51815aad",
+                "label": "Email",
+                "name": "person_email",
+                "type": "email",
+                "instructions": "The email of the person.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": ""
+            },
+            {
+                "key": "field_60afe53415aae",
+                "label": "Phone",
+                "name": "person_phone",
+                "type": "text",
+                "instructions": "The person's phone number.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            },
+            {
+                "key": "field_60afe54e15aaf",
+                "label": "Office",
+                "name": "person_office",
+                "type": "text",
+                "instructions": "The person's office (building and number).",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "person"
                 }
             ]
         ],

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -2324,7 +2324,7 @@
                 "label": "College",
                 "name": "person_college",
                 "type": "taxonomy",
-                "instructions": "Choose the college the faculty member is associate with.",
+                "instructions": "Choose the college the faculty member is associated with.",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
@@ -3057,7 +3057,7 @@
                 "label": "Title",
                 "name": "person_title",
                 "type": "text",
-                "instructions": "The title of the person",
+                "instructions": "The person's job title",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
@@ -3076,7 +3076,7 @@
                 "label": "Email",
                 "name": "person_email",
                 "type": "email",
-                "instructions": "The email of the person.",
+                "instructions": "The person's email address",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {

--- a/functions.php
+++ b/functions.php
@@ -16,6 +16,7 @@ include_once THEME_DIR . 'includes/ucf-alert-functions.php';
 include_once THEME_DIR . 'includes/phonebook-functions.php';
 include_once THEME_DIR . 'includes/statements-functions.php';
 include_once THEME_DIR . 'includes/post-list-layouts.php';
+include_once THEME_DIR . 'includes/people-functions.php';
 
 
 /**

--- a/includes/people-functions.php
+++ b/includes/people-functions.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Responsible for People custom post type functionality
+ */
+
+/**
+ * Modifies the rewrite rules for the People
+ * custom post type
+ * @author Jim Barnes
+ * @since 3.9.3
+ * @param array $args The argument array
+ * @return array
+ */
+function modify_people_post_type_args( $args ) {
+	$args['rewrite'] = array(
+		'slug'       => 'faculty',
+		'with_front' => false
+	);
+
+	return $args;
+}
+
+add_filter( 'ucf_people_post_type_args', 'modify_people_post_type_args', 10, 1 );

--- a/includes/people-functions.php
+++ b/includes/people-functions.php
@@ -7,7 +7,7 @@
  * Modifies the rewrite rules for the People
  * custom post type
  * @author Jim Barnes
- * @since 3.9.3
+ * @since 3.10.0
  * @param array $args The argument array
  * @return array
  */

--- a/template-faculty.php
+++ b/template-faculty.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Template Name: Faculty Research
+ * Template Post Type: person
+ */
+?>
+
+<?php get_header(); the_post(); ?>
+
+<?php the_content(); ?>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds the ACF Fields for People and additional fields for when the `template-faculty.php` template is used. In addition, the people custom post type's slug is updated to point to `/faculty/`.

**Motivation and Context**
We want to be able to reuse the people custom post type to serve up various types of faculty profiles.

**How Has This Been Tested?**
Changes are available for review in DEV.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
