### PR TITLE
Degree application deadline toggling

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1336,13 +1336,40 @@
                 "endpoint": 0
             },
             {
+                "key": "field_6127ec2c61df1",
+                "label": "Disable Deadlines",
+                "name": "disable_deadlines",
+                "type": "true_false",
+                "instructions": "If checked, application deadlines will <em>not<\/em> be displayed on this degree's profile.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "Disable",
+                "default_value": 0,
+                "ui": 1,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            },
+            {
                 "key": "field_5fa41b8492d13",
                 "label": "Alternate Section",
                 "name": "alternate_deadlines_section",
                 "type": "post_object",
                 "instructions": "Specify an alternate Section post to display in lieu of the standard Application Deadlines section on this degree's profile.  This value takes precedence over the Undergraduate\/Graduate Fallback Section values in the Customizer.",
                 "required": 0,
-                "conditional_logic": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_6127ec2c61df1",
+                            "operator": "!=",
+                            "value": "1"
+                        }
+                    ]
+                ],
                 "wrapper": {
                     "width": "",
                     "class": "",
@@ -1352,7 +1379,7 @@
                     "ucf_section"
                 ],
                 "taxonomy": "",
-                "allow_null": 0,
+                "allow_null": 1,
                 "multiple": 0,
                 "return_format": "id",
                 "ui": 1
@@ -1364,7 +1391,15 @@
                 "type": "repeater",
                 "instructions": "Specify a list of application deadlines to display on this degree's profile.  If provided, this list replaces the list of imported deadlines assigned to this degree.",
                 "required": 0,
-                "conditional_logic": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_6127ec2c61df1",
+                            "operator": "!=",
+                            "value": "1"
+                        }
+                    ]
+                ],
                 "wrapper": {
                     "width": "",
                     "class": "",

--- a/template-parts/degree/deadlines_apply.php
+++ b/template-parts/degree/deadlines_apply.php
@@ -2,183 +2,187 @@
 $post = isset( $post ) ? $post : get_queried_object();
 
 if ( $post->post_type === 'degree' ) :
-	$deadlines                 = get_degree_application_deadlines( $post );
-	$alternate_section         = null;
-	$degree_alternate_section  = get_field( 'alternate_deadlines_section', $post );
+	$disable_deadlines = get_field( 'disable_deadlines', $post );
+	if ( $disable_deadlines !== true ) :
 
-	// Retrieve a fallback section
-	$fallback_section_name = '';
-	if ( is_graduate_degree( $post ) ) {
-		$fallback_section_name = 'degree_deadlines_graduate_fallback';
-	} elseif ( is_undergraduate_degree( $post ) ) {
-		$fallback_section_name = 'degree_deadlines_undergraduate_fallback';
-	}
-	$fallback_section = $fallback_section_name ? get_theme_mod( $fallback_section_name ) : null;
+		$deadlines                 = get_degree_application_deadlines( $post );
+		$alternate_section         = null;
+		$degree_alternate_section  = get_field( 'alternate_deadlines_section', $post );
 
-	// Set $alternate_section to the degree-specific
-	// alternate Section post that's set, or a fallback
-	// if deadlines aren't available:
-	if ( $degree_alternate_section ) {
-		$alternate_section = $degree_alternate_section;
-	} elseif ( ! $deadlines ) {
-		$alternate_section = $fallback_section;
-	}
+		// Retrieve a fallback section
+		$fallback_section_name = '';
+		if ( is_graduate_degree( $post ) ) {
+			$fallback_section_name = 'degree_deadlines_graduate_fallback';
+		} elseif ( is_undergraduate_degree( $post ) ) {
+			$fallback_section_name = 'degree_deadlines_undergraduate_fallback';
+		}
+		$fallback_section = $fallback_section_name ? get_theme_mod( $fallback_section_name ) : null;
 
-	if ( $alternate_section ) :
-		echo do_shortcode( "[ucf-section id='$alternate_section']" );
-	elseif ( $deadlines ) :
-		$deadline_group_names = array_filter( array_keys( $deadlines ) );
-
-		// Modify heading text depending on the type of degree:
-		$heading_text = '<span class="d-inline-block">Application Deadlines</span>';
-		if ( is_undergraduate_degree( $post ) ) {
-			$heading_text = 'Undergraduate ' . $heading_text;
+		// Set $alternate_section to the degree-specific
+		// alternate Section post that's set, or a fallback
+		// if deadlines aren't available:
+		if ( $degree_alternate_section ) {
+			$alternate_section = $degree_alternate_section;
+		} elseif ( ! $deadlines ) {
+			$alternate_section = $fallback_section;
 		}
 
-		// Allow the heading for this section to display inline if
-		// only one deadline group is available, and there are
-		// fewer than 3 deadlines in that group:
-		$deadline_heading_show_inline = false;
-		if (
-			count( $deadlines ) === 1
-			&& count( $deadlines[array_key_first( $deadlines )] ) < 3
-		) {
-			$deadline_heading_show_inline = true;
-		}
-		$deadline_heading_col_class = $deadline_heading_show_inline ? 'col-lg-4 mb-4 mb-lg-0 mr-lg-5' : 'col-12 mb-4';
-		// We shouldn't have to do this, but, IE11:
-		$deadline_groups_col_class  = $deadline_heading_show_inline ? 'col' : 'col-12';
+		if ( $alternate_section ) :
+			echo do_shortcode( "[ucf-section id='$alternate_section']" );
+		elseif ( $deadlines ) :
+			$deadline_group_names = array_filter( array_keys( $deadlines ) );
+
+			// Modify heading text depending on the type of degree:
+			$heading_text = '<span class="d-inline-block">Application Deadlines</span>';
+			if ( is_undergraduate_degree( $post ) ) {
+				$heading_text = 'Undergraduate ' . $heading_text;
+			}
+
+			// Allow the heading for this section to display inline if
+			// only one deadline group is available, and there are
+			// fewer than 3 deadlines in that group:
+			$deadline_heading_show_inline = false;
+			if (
+				count( $deadlines ) === 1
+				&& count( $deadlines[array_key_first( $deadlines )] ) < 3
+			) {
+				$deadline_heading_show_inline = true;
+			}
+			$deadline_heading_col_class = $deadline_heading_show_inline ? 'col-lg-4 mb-4 mb-lg-0 mr-lg-5' : 'col-12 mb-4';
+			// We shouldn't have to do this, but, IE11:
+			$deadline_groups_col_class  = $deadline_heading_show_inline ? 'col' : 'col-12';
 ?>
-	<section id="application-deadline" aria-labelledby="application-deadlines-heading">
-		<div class="degree-deadline-wrap">
-			<div class="degree-deadline-row">
-				<!-- Left-hand surrounding pad, for desktop -->
-				<div class="degree-deadline-pad bg-primary"></div>
+		<section id="application-deadline" aria-labelledby="application-deadlines-heading">
+			<div class="degree-deadline-wrap">
+				<div class="degree-deadline-row">
+					<!-- Left-hand surrounding pad, for desktop -->
+					<div class="degree-deadline-pad bg-primary"></div>
 
-				<!-- Gold block, contains section heading and deadline groups -->
-				<div class="degree-deadline-content degree-deadline-content-deadlines">
-					<div class="row no-gutters w-100 h-100 d-lg-flex flex-wrap align-items-lg-center">
+					<!-- Gold block, contains section heading and deadline groups -->
+					<div class="degree-deadline-content degree-deadline-content-deadlines">
+						<div class="row no-gutters w-100 h-100 d-lg-flex flex-wrap align-items-lg-center">
 
-						<!-- Section heading column -->
-						<div class="<?php echo $deadline_heading_col_class; ?>">
-							<h2 id="application-deadlines-heading" class="h4 text-uppercase font-condensed text-center text-lg-left mb-0">
-								<?php echo $heading_text; ?>
-							</h2>
-						</div>
-
-						<!-- Deadline groups column -->
-						<div class="<?php echo $deadline_groups_col_class; ?>">
-							<div class="row d-lg-flex align-items-lg-center justify-content-lg-between flex-lg-nowrap">
-
-								<!-- Deadline group tabs column, if applicable -->
-								<?php if ( $deadline_group_names && count( $deadline_group_names ) > 1 ) : ?>
-								<div class="col-lg-auto d-flex mb-3 mb-lg-0 pr-lg-4">
-									<ul class="nav nav-pills degree-deadline-tab-nav flex-lg-column" id="degree-deadline-tabs" role="tablist">
-										<?php
-										foreach ( $deadline_group_names as $i => $group_name ) :
-											$nav_link_class = 'nav-link';
-											if ( $i === 0 ) $nav_link_class .= ' active';
-
-											$nav_link_slug = ( $group_name ) ? 'degree-deadlines--' . sanitize_title( $group_name ) : 'degree-deadlines--all';
-										?>
-										<li class="nav-item">
-											<a class="<?php echo $nav_link_class; ?>"
-												id="tab-<?php echo $nav_link_slug; ?>"
-												data-toggle="pill"
-												href="#<?php echo $nav_link_slug; ?>"
-												role="tab"
-												aria-controls="<?php echo $nav_link_slug; ?>"
-												aria-selected="true">
-												<?php echo $group_name; ?>
-											</a>
-										</li>
-										<?php endforeach; ?>
-									</ul>
-								</div>
-								<?php endif; ?>
-
-								<!-- Deadlines column -->
-								<div class="col mt-2 mt-lg-0">
-									<div class="tab-content" id="degree-deadlines">
-									<?php
-									$j = 0;
-									foreach ( $deadlines as $group_name => $group ) :
-									?>
-										<?php
-										// Only render a tab pane if more than one group
-										// is available (and tab nav is available)
-										$wrap_in_pane = ( $group_name && count( $deadline_group_names ) > 1 ) ? true : false;
-										if ( $wrap_in_pane ) :
-											$tab_pane_class = 'tab-pane fade';
-											if ( $j === 0 ) $tab_pane_class .= ' show active';
-											$j++;
-
-											$tab_pane_slug = ( $group_name ) ? 'degree-deadlines--' . sanitize_title( $group_name ) : 'degree-deadlines--all';
-										?>
-										<div class="<?php echo $tab_pane_class; ?>"
-											id="<?php echo $tab_pane_slug; ?>"
-											role="tabpanel"
-											aria-labelledby="tab-<?php echo $tab_pane_slug; ?>">
-										<?php endif; ?>
-
-											<dl class="row mb-0">
-												<?php foreach ( $group as $deadline ) : ?>
-												<div class="col-12 col-sm degree-deadline">
-													<dt class="font-weight-normal"><?php echo $deadline['term']; ?></dt>
-													<dd class="font-weight-bold mb-lg-0"><?php echo $deadline['deadline']; ?></dd>
-												</div>
-												<?php endforeach; ?>
-											</dl>
-
-										<?php if ( $wrap_in_pane ) : ?>
-										</div>
-										<?php endif; ?>
-									<?php endforeach; ?>
-									</div>
-								</div>
-
+							<!-- Section heading column -->
+							<div class="<?php echo $deadline_heading_col_class; ?>">
+								<h2 id="application-deadlines-heading" class="h4 text-uppercase font-condensed text-center text-lg-left mb-0">
+									<?php echo $heading_text; ?>
+								</h2>
 							</div>
-						</div>
 
+							<!-- Deadline groups column -->
+							<div class="<?php echo $deadline_groups_col_class; ?>">
+								<div class="row d-lg-flex align-items-lg-center justify-content-lg-between flex-lg-nowrap">
+
+									<!-- Deadline group tabs column, if applicable -->
+									<?php if ( $deadline_group_names && count( $deadline_group_names ) > 1 ) : ?>
+									<div class="col-lg-auto d-flex mb-3 mb-lg-0 pr-lg-4">
+										<ul class="nav nav-pills degree-deadline-tab-nav flex-lg-column" id="degree-deadline-tabs" role="tablist">
+											<?php
+											foreach ( $deadline_group_names as $i => $group_name ) :
+												$nav_link_class = 'nav-link';
+												if ( $i === 0 ) $nav_link_class .= ' active';
+
+												$nav_link_slug = ( $group_name ) ? 'degree-deadlines--' . sanitize_title( $group_name ) : 'degree-deadlines--all';
+											?>
+											<li class="nav-item">
+												<a class="<?php echo $nav_link_class; ?>"
+													id="tab-<?php echo $nav_link_slug; ?>"
+													data-toggle="pill"
+													href="#<?php echo $nav_link_slug; ?>"
+													role="tab"
+													aria-controls="<?php echo $nav_link_slug; ?>"
+													aria-selected="true">
+													<?php echo $group_name; ?>
+												</a>
+											</li>
+											<?php endforeach; ?>
+										</ul>
+									</div>
+									<?php endif; ?>
+
+									<!-- Deadlines column -->
+									<div class="col mt-2 mt-lg-0">
+										<div class="tab-content" id="degree-deadlines">
+										<?php
+										$j = 0;
+										foreach ( $deadlines as $group_name => $group ) :
+										?>
+											<?php
+											// Only render a tab pane if more than one group
+											// is available (and tab nav is available)
+											$wrap_in_pane = ( $group_name && count( $deadline_group_names ) > 1 ) ? true : false;
+											if ( $wrap_in_pane ) :
+												$tab_pane_class = 'tab-pane fade';
+												if ( $j === 0 ) $tab_pane_class .= ' show active';
+												$j++;
+
+												$tab_pane_slug = ( $group_name ) ? 'degree-deadlines--' . sanitize_title( $group_name ) : 'degree-deadlines--all';
+											?>
+											<div class="<?php echo $tab_pane_class; ?>"
+												id="<?php echo $tab_pane_slug; ?>"
+												role="tabpanel"
+												aria-labelledby="tab-<?php echo $tab_pane_slug; ?>">
+											<?php endif; ?>
+
+												<dl class="row mb-0">
+													<?php foreach ( $group as $deadline ) : ?>
+													<div class="col-12 col-sm degree-deadline">
+														<dt class="font-weight-normal"><?php echo $deadline['term']; ?></dt>
+														<dd class="font-weight-bold mb-lg-0"><?php echo $deadline['deadline']; ?></dd>
+													</div>
+													<?php endforeach; ?>
+												</dl>
+
+											<?php if ( $wrap_in_pane ) : ?>
+											</div>
+											<?php endif; ?>
+										<?php endforeach; ?>
+										</div>
+									</div>
+
+								</div>
+							</div>
+
+						</div>
 					</div>
-				</div>
 
-				<!-- Gray block, contains apply CTA -->
-				<div class="degree-deadline-content degree-deadline-content-start <?php if ( ! $deadline_heading_show_inline ) { ?>degree-deadline-content-start-condensed<?php } ?> text-center text-lg-left bg-gray-darker">
-					<div class="row no-gutters d-lg-flex justify-content-lg-center align-self-lg-center">
+					<!-- Gray block, contains apply CTA -->
+					<div class="degree-deadline-content degree-deadline-content-start <?php if ( ! $deadline_heading_show_inline ) { ?>degree-deadline-content-start-condensed<?php } ?> text-center text-lg-left bg-gray-darker">
+						<div class="row no-gutters d-lg-flex justify-content-lg-center align-self-lg-center">
 
-						<!-- CTA lead text column -->
-						<div class="col-12 col-lg-auto align-self-lg-center pr-xl-3">
-							<h2 class="h5 text-uppercase font-condensed mb-4 mb-lg-3 <?php if ( $deadline_heading_show_inline ) { ?>mb-xl-0<?php } ?>">
-								<span class="d-inline-block <?php if ( $deadline_heading_show_inline ) { ?>d-xl-block<?php } ?>">
-									Ready to
-								</span>
-								<span class="d-inline-block">
-									get started?
-								</span>
-							</h2>
+							<!-- CTA lead text column -->
+							<div class="col-12 col-lg-auto align-self-lg-center pr-xl-3">
+								<h2 class="h5 text-uppercase font-condensed mb-4 mb-lg-3 <?php if ( $deadline_heading_show_inline ) { ?>mb-xl-0<?php } ?>">
+									<span class="d-inline-block <?php if ( $deadline_heading_show_inline ) { ?>d-xl-block<?php } ?>">
+										Ready to
+									</span>
+									<span class="d-inline-block">
+										get started?
+									</span>
+								</h2>
+							</div>
+
+							<!-- Apply button column -->
+							<div class="col-12 col-lg-auto align-self-lg-center">
+								<?php
+								echo get_degree_apply_button(
+									$post,
+									'btn btn-lg btn-primary rounded',
+									'',
+									'Apply Today'
+								);
+								?>
+							</div>
+
 						</div>
-
-						<!-- Apply button column -->
-						<div class="col-12 col-lg-auto align-self-lg-center">
-							<?php
-							echo get_degree_apply_button(
-								$post,
-								'btn btn-lg btn-primary rounded',
-								'',
-								'Apply Today'
-							);
-							?>
-						</div>
-
 					</div>
-				</div>
 
-				<!-- Right-hand surrounding pad, for desktop -->
-				<div class="degree-deadline-pad bg-gray-darker"></div>
+					<!-- Right-hand surrounding pad, for desktop -->
+					<div class="degree-deadline-pad bg-gray-darker"></div>
+				</div>
 			</div>
-		</div>
-	</section>
+		</section>
 <?php
+		endif;
 	endif;
 endif;


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
**Recommend viewing this PR with whitespace changes disabled.**

- Added ability to disable the application deadlines section entirely on degree profiles
- Fixed issue with the "Alternate Section" field for replacing the deadlines section which prevented its value from being set to null later

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Sometimes the deadlines we have imported are wrong, and there's not a good quick way at the moment to hide them without replacing the deadlines with an alternate section
- Once you set an alternate section previously, there was no way of wiping out the value later

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in QA

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
