### PR TITLE
Replaced usage of `after_body_open` with `wp_body_open`

### DIFF
--- a/header.php
+++ b/header.php
@@ -13,7 +13,7 @@
 		<div id="ucfhb" style="min-height: 50px; background-color: #000;"></div>
 		<?php endif; ?>
 
-		<?php do_action( 'after_body_open' ); ?>
+		<?php do_action( 'wp_body_open' ); ?>
 
 		<header class="site-header">
 			<?php echo get_header_markup(); ?>

--- a/includes/meta.php
+++ b/includes/meta.php
@@ -241,7 +241,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 	endif;
 }
 
-add_action( 'after_body_open', 'google_tag_manager_noscript', 0 );
+add_action( 'wp_body_open', 'google_tag_manager_noscript', 0 );
 
 
 /**

--- a/includes/ucf-alert-functions.php
+++ b/includes/ucf-alert-functions.php
@@ -96,6 +96,6 @@ if ( class_exists( 'UCF_Alert_Common' ) ) {
 	function mainsite_display_alert() {
 		echo UCF_Alert_Common::display_alert( 'faicon', array() );
 	}
-	add_filter( 'after_body_open', 'mainsite_display_alert', 1 );
+	add_filter( 'wp_body_open', 'mainsite_display_alert', 1 );
 
 }


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Because `wp_body_open` exists, and to mirror changes in the UCF WP Theme (related issue: https://github.com/UCF/UCF-WordPress-Theme/issues/115).

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
