### PR TITLE
Faculty field updates

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -3774,36 +3774,49 @@
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
-                    "width": "50",
+                    "width": "",
                     "class": "",
                     "id": ""
                 },
-                "default_value": "",
-                "placeholder": "",
-                "prepend": "",
-                "append": "",
-                "maxlength": "",
-                "copy_to_clipboard": false
+                "copy_to_clipboard": 0,
+                "display_type": "text"
             },
             {
                 "key": "field_60bf8388c8af9",
-                "label": "Job Title",
-                "name": "person_title",
-                "type": "read_only",
+                "label": "Job Titles",
+                "name": "person_titles",
+                "type": "repeater",
                 "instructions": "",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
-                    "width": "50",
-                    "class": "",
+                    "width": "",
+                    "class": "repeater-field-readonly repeater-field-hide-thead",
                     "id": ""
                 },
-                "default_value": "",
-                "placeholder": "",
-                "prepend": "",
-                "append": "",
-                "maxlength": "",
-                "copy_to_clipboard": false
+                "collapsed": "",
+                "min": 0,
+                "max": 0,
+                "layout": "table",
+                "button_label": "",
+                "sub_fields": [
+                    {
+                        "key": "field_6193ccaae5993",
+                        "label": "Title",
+                        "name": "job_title",
+                        "type": "read_only",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "copy_to_clipboard": 0,
+                        "display_type": "text"
+                    }
+                ]
             },
             {
                 "key": "field_60bf85ec22be3",
@@ -3814,7 +3827,7 @@
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
-                    "width": "40",
+                    "width": "50",
                     "class": "",
                     "id": ""
                 },
@@ -3830,39 +3843,7 @@
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
-                    "width": "30",
-                    "class": "",
-                    "id": ""
-                },
-                "copy_to_clipboard": 0,
-                "display_type": "text"
-            },
-            {
-                "key": "field_60bf8395c8afc",
-                "label": "Office Bldg and Number",
-                "name": "person_office",
-                "type": "read_only",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "30",
-                    "class": "",
-                    "id": ""
-                },
-                "copy_to_clipboard": 0,
-                "display_type": "text"
-            },
-            {
-                "key": "field_60bf859c32c6b",
-                "label": "Department",
-                "name": "person_department",
-                "type": "read_only",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
+                    "width": "50",
                     "class": "",
                     "id": ""
                 },

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -3971,7 +3971,7 @@
                         "name": "end_date",
                         "type": "read_only",
                         "instructions": "",
-                        "required": 1,
+                        "required": 0,
                         "conditional_logic": 0,
                         "wrapper": {
                             "width": "",

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -3766,6 +3766,26 @@
                 "endpoint": 0
             },
             {
+                "key": "field_61928d9a03aea",
+                "label": "Last Name",
+                "name": "person_last_name",
+                "type": "read_only",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "50",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": "",
+                "copy_to_clipboard": false
+            },
+            {
                 "key": "field_60bf8388c8af9",
                 "label": "Job Title",
                 "name": "person_title",
@@ -3774,7 +3794,7 @@
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
-                    "width": "",
+                    "width": "50",
                     "class": "",
                     "id": ""
                 },

--- a/includes/config.php
+++ b/includes/config.php
@@ -1506,6 +1506,29 @@ add_action( 'acf/input/admin_footer', 'read_only_repeater_fields' );
 
 
 /**
+ * Hides the <thead> of repeater fields that have
+ * the CSS class `repeater-field-hide-thead` applied to
+ * them to improve ease of readability.
+ *
+ * @since 3.10.0
+ * @author Cadie Stockman
+ */
+function hidden_thead_repeater_fields() {
+	ob_start();
+?>
+	<style type="text/css">
+		.repeater-field-hide-thead thead {
+			display: none;
+		}
+	</style>
+<?php
+	echo ob_get_clean();
+}
+
+add_action( 'acf/input/admin_head', 'hidden_thead_repeater_fields' );
+
+
+/**
  * Adds new columns for displaying degree template names
  * and the types of available degree descriptions in the
  * degree list admin view.


### PR DESCRIPTION
**Description**

- Adds an ACF field for last_name (Resolves #367)
- Update Job Title field to a repeater field to allow multiple job titles
- Sets the education's 'end_date' field to not required (posts were not able to be updated if end_date was not imported in--some education data does not have a start or end date)
- Adds the `hidden_thead_repeater_fields` function that hides the table head for repeater fields if the class is set on the field in the ACF field group admin. I thought this helped improve readability there, otherwise the Job Titles/Title heading is duplicated

**Motivation and Context**
Updates the fields for the researcher import updates. Related to the [Main-Site-Utilities-Plugin PR #16](https://github.com/UCF/Main-Site-Utilities-Plugin/pull/16).

**How Has This Been Tested?**
Changes viewable in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
