### PR TITLE
Term post type filter

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -472,4 +472,41 @@ function get_colleges_grid( $exclude_term=null ) {
 
 	return ob_get_clean();
 }
+
+function modify_rest_departments_query( $args, $request ) {
+	if ( isset( $request['post_types'] ) && ! empty( $request['post_types'] ) ) {
+		$args['post_types'] = $request['post_types'];
+	}
+
+	return $args;
+}
+
+add_filter( 'rest_departments_query', 'modify_rest_departments_query', 10, 2 );
+
+
+/**
+ * Custom filter for filtering terms by post_type
+ * @author Jim Barnes
+ * @since v3.10.0
+ * @param array $pieces The pieces of the query to be sent to MySQL ('select', 'join', 'where')
+ * @param array $taxonomies The taxonomies being filtered
+ * @param array $args The get_terms arguments
+ * @return array $pieces The modified $pieces array
+ */
+function filter_terms_by_post_type( $pieces, $taxonomies, $args ) {
+	if ( isset( $args['post_types'] ) ) {
+		global $wpdb;
+
+		$pieces['join'] .= " INNER JOIN $wpdb->term_relationships as tr ON tr.term_taxonomy_id = tt.term_taxonomy_id
+							 INNER JOIN $wpdb->posts as p ON p.ID = tr.object_id ";
+
+		$post_types = $args['post_types'];
+		$pieces['where'] .= $wpdb->prepare( " AND p.post_type IN(%s) GROUP BY t.term_id", $post_types );
+	}
+
+	return $pieces;
+}
+
+add_filter( 'terms_clauses', 'filter_terms_by_post_type', 10, 3 );
+
 ?>


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Modifies the built in `departments` API to be filterable by `post_types`, allowing for results only to be returned that have posts assigned _of that post type_. 

**Motivation and Context**
This removes the issue where departments are returned that currently have no people assigned to them, but _do_ have programs assigned to them.

**How Has This Been Tested?**
Changes are available for review in DEV.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
