### PR TITLE
Display job title(s) on the faculty profile template

### DIFF
--- a/template-parts/layout/header/content-person.php
+++ b/template-parts/layout/header/content-person.php
@@ -10,7 +10,7 @@ $title    = get_header_title( $obj );
 $heading_color_class = get_theme_mod_or_default( 'person_heading_text_color' ) === 'person-heading-text-inverse' ? ' person-heading-text-inverse' : '';
 
 if ( $title ):
-	$subtitles  = get_field( 'person_titles', $obj );
+	$subtitles = get_field( 'person_titles', $obj );
 	$thumbnail = get_person_thumbnail(
 		$obj,
 		'medium',

--- a/template-parts/layout/header/content-person.php
+++ b/template-parts/layout/header/content-person.php
@@ -10,7 +10,7 @@ $title    = get_header_title( $obj );
 $heading_color_class = get_theme_mod_or_default( 'person_heading_text_color' ) === 'person-heading-text-inverse' ? ' person-heading-text-inverse' : '';
 
 if ( $title ):
-	$subtitle  = wptexturize( get_field( 'person_title', $obj ) );
+	$subtitles  = get_field( 'person_titles', $obj );
 	$thumbnail = get_person_thumbnail(
 		$obj,
 		'medium',
@@ -34,12 +34,24 @@ if ( $title ):
 				<h1 class="mt-4 mb-3 pt-sm-2<?php echo $heading_color_class; ?>">
 					<?php echo $title; ?>
 				</h1>
+				<div class="mb-4">
+				<?php if ( $subtitles ) :
+				?>
+					<span class="lead d-inline-block mb-2<?php echo $heading_color_class; ?>">
+					<?php
+					foreach( $subtitles as $key => $title ) :
+						$job_title = $title['job_title'];
 
-				<?php if ( $subtitle ) : ?>
-				<span class="lead d-block mb-4 <?php echo $heading_color_class; ?>">
-					<?php echo $subtitle; ?>
-				</span>
+						echo $job_title;
+
+						if ( $key !== array_key_last( $subtitles ) ) {
+							echo ",";
+						}
+					?>
+					<?php endforeach; ?>
+					</span>
 				<?php endif; ?>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/template-parts/layout/header/content-person.php
+++ b/template-parts/layout/header/content-person.php
@@ -38,17 +38,7 @@ if ( $title ):
 				<?php if ( $subtitles ) :
 				?>
 					<span class="lead d-inline-block mb-2<?php echo $heading_color_class; ?>">
-					<?php
-					foreach( $subtitles as $key => $title ) :
-						$job_title = $title['job_title'];
-
-						echo $job_title;
-
-						if ( $key !== array_key_last( $subtitles ) ) {
-							echo ",";
-						}
-					?>
-					<?php endforeach; ?>
+					<?php echo implode( ', ', array_column( $subtitles, 'job_title' ) ); ?>
 					</span>
 				<?php endif; ?>
 				</div>

--- a/template-parts/person/at_a_glance.php
+++ b/template-parts/person/at_a_glance.php
@@ -87,7 +87,7 @@ if ( $post->post_type === 'person' ) :
 											<span class="fa fa-fw fa-lg fa-envelope mr-1" aria-hidden="true"></span>
 											<a href="mailto:<?php echo $email; ?>">
 												Email
-												<span class="sr-only"> <?php echo $result->email; ?></span>
+												<span class="sr-only"> <?php echo $email; ?></span>
 											</a>
 										</dd>
 										<?php endif; ?>


### PR DESCRIPTION
**Description**
Allows the faculty profiles to display one or more job titles.

**Motivation and Context**
Faculty are able to have more than one job title listed so we needed to update this template so that one/multiple are shown. Resolves (the template part of) #369.

**How Has This Been Tested?**
Viewable in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
