### PR TITLE
Added logic to import ranked degrees

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -18,6 +18,8 @@ define( 'THEME_CUSTOMIZER_DEFAULTS', serialize( array(
 	'degrees_graduate_application'        => 'https://application.graduate.ucf.edu/#/',
 	'degrees_graduate_rfi_url_base'       => 'https://applynow.graduate.ucf.edu/register/',
 	'degrees_graduate_rfi_form_id'        => 'bad6c39a-5c60-4895-9128-5785ce014085',
+	'degrees_careers_weight_threshold'    => 0.5,
+	'degrees_careers_per_program_limit'   => 10,
 	'catalog_desc_cta_intro'              => '',
 	'degree_deadlines_undergraduate_deadline_order' => 'Freshmen, Transfers, International',
 	'degree_deadlines_graduate_deadline_order'      => 'Domestic, International',
@@ -655,6 +657,40 @@ function define_customizer_fields( $wp_customize ) {
 			'type'        => 'textarea',
 			'label'       => 'Degree Career Fallback Intro Text',
 			'description' => 'Text to display next to a program\'s careers when a list of learnable skills is not set.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-skills_careers'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_careers_weight_threshold',
+		array(
+			'default' => get_theme_mod_default( 'degrees_careers_weight_threshold' )
+		)
+	);
+
+	$wp_customize->add_control(
+		'degrees_careers_weight_threshold',
+		array(
+			'type'        => 'text',
+			'label'       => 'Degree Career Weight Threshold',
+			'description' => 'The weight threshold a weighted job position must meet in order to be imported.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-skills_careers'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_careers_per_program_limit',
+		array(
+			'default' => get_theme_mod_default( 'degrees_careers_per_program_limit' )
+		)
+	);
+
+	$wp_customize->add_control(
+		'degrees_careers_per_program_limit',
+		array(
+			'type'        => 'text',
+			'label'       => 'Degree Career Program Limit',
+			'description' => 'The maximum number of job careers to import from the search service.',
 			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-skills_careers'
 		)
 	);

--- a/includes/degree-import-functions.php
+++ b/includes/degree-import-functions.php
@@ -146,11 +146,37 @@ add_filter( 'ucf_degree_get_post_metadata', 'mainsite_degree_format_post_data', 
  * @return array
  */
 function mainsite_degree_get_post_terms( $terms, $program ) {
-	$careers = main_site_get_remote_response_json( $program->careers, array() );
-
-	$terms['career_paths'] = $careers;
+	$careers = main_site_get_remote_response_json( "{$program->careers}ranked/", array() );
+	$terms['career_paths'] = mainsite_filter_career_paths( $careers );
 
 	return $terms;
 }
 
 add_filter( 'ucf_degree_get_post_terms', 'mainsite_degree_get_post_terms', 10, 2 );
+
+
+/**
+ * Filters the careers from the ranked endpoint
+ * by weight and limiting to the max number of
+ * career paths.
+ *
+ * @author Jim Barnes
+ * @since 3.4.0
+ * @param  array $careers The array of career objects from the search service
+ * @return array[string] The array of career names
+ */
+function mainsite_filter_career_paths( $careers ) {
+	$threshold = get_theme_mod( 'degrees_careers_weight_threshold' );
+	$limit = get_theme_mod( 'degrees_careers_per_program_limit' );
+	$retval = array();
+
+	foreach ( $careers as $i => $career ) {
+		if ( $career->weight < $threshold || $i === $limit - 1 ) {
+			break;
+		}
+
+		$retval[] = $career->job;
+	}
+
+	return $retval;
+}


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Updates the way careers get imported to use the "/ranked" endpoint, which has weighted job positions per program. This allows a subset of program careers to be imported, based on (1) the weight meeting a configurable threshold and (2) limits the number of careers to a configurable number.

**Motivation and Context**
We want to be able to better control the careers that get imported.

**How Has This Been Tested?**
Changes area available for review in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
