### PR TITLE
College Degree Search URL Update

### DIFF
--- a/taxonomy-colleges.php
+++ b/taxonomy-colleges.php
@@ -13,7 +13,7 @@ $stats_background = get_field( 'stats_background_image', $term )['url'] ?? null;
 // Degree
 $degree_title = get_field( 'degree_search_title', $term ) ?: 'Search Degrees';
 $degree_copy = get_field( 'degree_search_copy', $term );
-$degree_search_url = "https://www.ucf.edu/degree-search/college/" . $term->slug . "/";
+$degree_search_url = get_permalink( get_page_by_path( 'degree-search' ) );
 $degree_types = get_field( 'degree_types_available', $term );
 $degree_types = map_degree_types( $degree_types );
 $top_degrees = display_top_degrees( $term );
@@ -93,7 +93,7 @@ $spotlight = get_field( 'college_spotlight', $term );
 						<h3 class="browse-by-heading h6 heading-sans-serif text-uppercase">Or browse by:</h3>
 						<ul class="browse-by-list list-chevrons">
 							<?php foreach( $degree_types as $slug => $name ) : ?>
-							<li><a href="<?php echo $degree_search_url . $slug . '/'; ?>" class="text-inverse"><?php echo $name . 's'; ?></a></li>
+							<li><a href="<?php echo sprintf( "%s%s/college/%s/", $degree_search_url, $slug, $term->slug ); ?>" class="text-inverse"><?php echo $name . 's'; ?></a></li>
 							<?php endforeach; ?>
 						</ul>
 						<?php endif; ?>

--- a/taxonomy-colleges.php
+++ b/taxonomy-colleges.php
@@ -13,7 +13,7 @@ $stats_background = get_field( 'stats_background_image', $term )['url'] ?? null;
 // Degree
 $degree_title = get_field( 'degree_search_title', $term ) ?: 'Search Degrees';
 $degree_copy = get_field( 'degree_search_copy', $term );
-$degree_search_url = "https://www.ucf.edu/degree-search/#!/college/" . $term->slug . "/";
+$degree_search_url = "https://www.ucf.edu/degree-search/college/" . $term->slug . "/";
 $degree_types = get_field( 'degree_types_available', $term );
 $degree_types = map_degree_types( $degree_types );
 $top_degrees = display_top_degrees( $term );


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Updates the way degree-search URLs are generated to ensure they point to the right place.

**Motivation and Context**
With the recent changes to the degree search, some of the older URL formats will no longer work. Under the older format, variables could be swapped about without issue, e.g `/college/arts-humanities/master/` would work as well as `/master/college/arts-humanities/`.

Within the new URL scheme parameters must be passed in a particular order. In the above example only `/master/college/arts-humanities/` will work now. As a stop gap until this can be corrected on the degree search javascript routing itself, we're working to make sure the proper URLs are being used in the various places we link to the degree search. The college template required updating to ensure the URLs are correct.

**How Has This Been Tested?**
Changes are available in DEV and QA for review.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
