### PR TITLE
Added fallback logic for degree fallback header images

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -525,6 +525,54 @@
                 ]
             },
             {
+                "key": "field_6491b33c708e7",
+                "label": "Degree Fallback Header Image (-sm+)",
+                "name": "degree_fallback_header_image",
+                "type": "image",
+                "instructions": "Header image to display at the -sm breakpoint and up.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "return_format": "id",
+                "preview_size": "header-img-sm",
+                "library": "all",
+                "min_width": 1200,
+                "min_height": "",
+                "min_size": "",
+                "max_width": "",
+                "max_height": "",
+                "max_size": "",
+                "mime_types": "png,jpg,jpeg"
+            },
+            {
+                "key": "field_6491b3cc708e8",
+                "label": "Degree Fallback Header Image (-xs)",
+                "name": "degree_fallback_header_image_xs",
+                "type": "image",
+                "instructions": "Header image to display at the -xs breakpoint.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "return_format": "id",
+                "preview_size": "header-img",
+                "library": "all",
+                "min_width": 575,
+                "min_height": "",
+                "min_size": "",
+                "max_width": "",
+                "max_height": "",
+                "max_size": "",
+                "mime_types": "png,jpg,jpeg"
+            },
+            {
                 "key": "field_59a5a672eab38",
                 "label": "Call to Action Bar",
                 "name": "",

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -560,8 +560,8 @@ if ( ! is_admin() ) {
 	 *
 	 * @author Jim Barnes
 	 * @since v3.14.2
-	 * @param  WP_Term|int $tag_arr
-	 * @return WP_Term|int
+	 * @param  WP_Term|int|string $tag_arr
+	 * @return WP_Term|int|string
 	 */
 	function comma_interest_filter( $tag_arr ) {
 		if ( is_int( $tag_arr ) || is_string( $tag_arr ) ) return $tag_arr;

--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -469,7 +469,7 @@ function main_site_format_degree_data( $post_meta ) {
 	setlocale(LC_MONETARY, 'en_US');
 
 	if ( isset( $post_meta['degree_avg_annual_earnings'] ) && ! empty( $post_meta['degree_avg_annual_earnings'] ) ) {
-		$post_meta['degree_avg_annual_earnings'] = money_format( '%n', floatval( $post_meta['degree_avg_annual_earnings'] ) );
+		$post_meta['degree_avg_annual_earnings'] = sprintf( '%01.2f', floatval( $post_meta['degree_avg_annual_earnings'] ) );
 	}
 
 	if ( isset( $post_meta['degree_employed_full_time'] ) && ! empty( $post_meta['degree_employed_full_time'] ) ) {
@@ -564,7 +564,7 @@ if ( ! is_admin() ) {
 	 * @return WP_Term|int
 	 */
 	function comma_interest_filter( $tag_arr ) {
-		if ( is_int( $tag_arr ) ) return $tag_arr;
+		if ( is_int( $tag_arr ) || is_string( $tag_arr ) ) return $tag_arr;
 
 		$retval = $tag_arr;
 		if ( $tag_arr->taxonomy === 'interests' && strpos( $tag_arr->name, '--' ) ) {

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -21,6 +21,11 @@ function get_header_images( $obj ) {
 		}
 
 		if ( $college ) {
+			$retval['header_image'] = get_field( 'degree_fallback_header_image', 'colleges_' . $college->term_id );
+			$retval['header_image_xs'] = get_field( 'degree_fallback_header_image_xs', 'colleges_' . $college->term_id );
+		}
+
+		if ( ! $retval['header_image'] ) {
 			$retval['header_image'] = get_field( 'page_header_image', 'colleges_' . $college->term_id );
 			$retval['header_image_xs'] = get_field( 'page_header_image_xs', 'colleges_' . $college->term_id );
 		}


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds an additional set of fields for the fallback degree page images. Currently, if the degree pages do not have a specific header image selected, they will fall back to the header images used for the College they're assigned to. With this change, the degree pages will first look for the `page_header_image` and `page_header_image_xs` fields for the degree, then the `degree_fallback_header_image` and `degree_fallback_header_image_xs` fields of the college, and then fallback to the `page_header_image` and `page_header_image_xs` fields for the college. This final fallback is for backwards compatibility for whenever the code is initially pushed.

**Motivation and Context**
This allows us to use separate headers for the college profile page and the fallback image for the degrees.

**How Has This Been Tested?**
Changes have been validated locally and will be further validated in the Pantheon environment following the merging of this pull request.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
