### PR TITLE
Updated experts slug

### DIFF
--- a/includes/people-functions.php
+++ b/includes/people-functions.php
@@ -13,7 +13,7 @@
  */
 function modify_people_post_type_args( $args ) {
 	$args['rewrite'] = array(
-		'slug'       => 'experts',
+		'slug'       => 'expert',
 		'with_front' => false
 	);
 
@@ -21,6 +21,7 @@ function modify_people_post_type_args( $args ) {
 }
 
 add_filter( 'ucf_people_post_type_args', 'modify_people_post_type_args', 10, 1 );
+
 
 /**
  * Modifies the post_types array for the expertise
@@ -214,7 +215,7 @@ function get_additional_contributors_markup( $work ) {
 function enqueue_expert_section_scripts() {
 	$obj = get_queried_object();
 
-	if ( $obj->post_type === 'person' ) {
+	if ( $obj && $obj->post_type === 'person' ) {
 		$theme = wp_get_theme();
 		$theme_version = $theme->get( 'Version' );
 


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Updates the slug used for the people custom post type from `experts` to `expert`. There is not currently a way to use `experts` as a slug and still have pagination working properly on the experts search page.

Also, a quick null check added to a function to quiet a PHP warning.

**Motivation and Context**
We want to get pagination working again. We will try to switch this back to `experts` in the coming weeks if we can find a way to make it work.

**How Has This Been Tested?**
Tested locally.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
