### PR TITLE
Added webp as allowed upload image type for headers

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -596,7 +596,7 @@
                 "max_width": "",
                 "max_height": "",
                 "max_size": "",
-                "mime_types": "png,jpg,jpeg",
+                "mime_types": "png,jpg,jpeg,webp",
                 "preview_size": "header-img-lg",
                 "library": "all"
             },
@@ -624,7 +624,7 @@
                 "max_width": "",
                 "max_height": "",
                 "max_size": "",
-                "mime_types": "png,jpg,jpeg",
+                "mime_types": "png,jpg,jpeg,webp",
                 "preview_size": "header-img-md",
                 "library": "all"
             },
@@ -652,7 +652,7 @@
                 "max_width": "",
                 "max_height": "",
                 "max_size": "",
-                "mime_types": "png,jpg,jpeg",
+                "mime_types": "png,jpg,jpeg,webp",
                 "preview_size": "header-img",
                 "library": "all"
             },
@@ -4415,7 +4415,7 @@
                 "max_width": "",
                 "max_height": "",
                 "max_size": "",
-                "mime_types": "png,jpg,jpeg",
+                "mime_types": "png,jpg,jpeg,webp",
                 "preview_size": "header-img-lg",
                 "library": "all"
             },
@@ -4443,7 +4443,7 @@
                 "max_width": "",
                 "max_height": "",
                 "max_size": "",
-                "mime_types": "png,jpg,jpeg",
+                "mime_types": "png,jpg,jpeg,webp",
                 "preview_size": "header-img-md",
                 "library": "all"
             },
@@ -4471,7 +4471,7 @@
                 "max_width": "",
                 "max_height": "",
                 "max_size": "",
-                "mime_types": "png,jpg,jpeg",
+                "mime_types": "png,jpg,jpeg,webp",
                 "preview_size": "header-img",
                 "library": "all"
             },


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Updated the ACF export file to have the updated file types allowed for uploads on header images.

**Motivation and Context**
We want to be able to use webps.

**How Has This Been Tested?**
Currently working in test.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
