### PR TITLE
Fastly Formats

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -37,7 +37,8 @@ define( 'THEME_CUSTOMIZER_DEFAULTS', serialize( array(
 	'faculty_search_page_path'            => 'faculty-search',
 	'expert_search_page_path'             => 'experts',
 	'expert_request_button_text'          => 'Contact this expert',
-	'search_service_url'                  => 'https://search.smca.ucf.edu/service.php'
+	'search_service_url'                  => 'https://search.smca.ucf.edu/service.php',
+	'fastly_header_format'                => '',
 ) ) );
 
 function __init__() {
@@ -915,6 +916,21 @@ function define_customizer_fields( $wp_customize ) {
 			'label'       => 'Exclude Stylesheets',
 			'description' => 'Specify a comma-separated list of stylesheet handles that should not be loaded asynchronously when critical CSS is in use.',
 			'section'     => THEME_CUSTOMIZER_PREFIX . 'performance'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'fastly_header_format'
+	);
+
+	$wp_customize->add_control(
+		'fastly_header_format',
+		array(
+			'type'        => 'text',
+			'label'       => 'Fastly Header Image Format',
+			'description' => 'Specifies the image format to request from the Fastly caching platform. Appends the query parameter <code>?format=</code> to the end of the image URL.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'performance',
+			'default'     => get_theme_mod_default( 'fastly_header_format' )
 		)
 	);
 

--- a/includes/media-backgrounds.php
+++ b/includes/media-backgrounds.php
@@ -87,7 +87,7 @@ function get_media_background_picture_srcs( $attachment_xs_id, $attachment_md_id
 
 	if ( ! empty( $heading_format  ) ) {
 		foreach( $bg_images as $key => $image ) {
-			$bg_images[$key] .= "?format=$heading_format";
+			$bg_images[$key] .= "?auto=$heading_format";
 		}
 	}
 

--- a/includes/media-backgrounds.php
+++ b/includes/media-backgrounds.php
@@ -83,6 +83,14 @@ function get_media_background_picture_srcs( $attachment_xs_id, $attachment_md_id
 	// Strip out false-y values (in case an attachment failed to return somewhere)
 	$bg_images = array_filter( $bg_images );
 
+	$heading_format = get_theme_mod_or_default( 'fastly_header_format' );
+
+	if ( ! empty( $heading_format  ) ) {
+		foreach( $bg_images as $key => $image ) {
+			$bg_images[$key] .= "?format=$heading_format";
+		}
+	}
+
 	return $bg_images;
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Allows a query parameter to be added to the end of heading assets. If the `webp` extension is added, when images are fetched the query param `format=webp` will be added to the end of the URL. This will tell the Fastly caching layer we don't want it to deliver a `avif` file, and instead we want a `webp`.

**Motivation and Context**
When Fastly delivers `avif` files, they compressed using a lossy method, and the quality can be very noticeably bad on images with text included.

**How Has This Been Tested?**
The query parameter method has been verified manually prior to this pull request. The code that adds to query parameter to the request URLs has been tested locally.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
