### PR TITLE
Disclaimer Content Alignment

### DIFF
--- a/template-parts/degree/deadlines_apply.php
+++ b/template-parts/degree/deadlines_apply.php
@@ -147,7 +147,7 @@ if ( $post->post_type === 'degree' ) :
 							</div>
 
 							<?php if ( $undergraduate_deadlines_disclaimer || $graduate_deadlines_disclaimer ) : ?>
-							<div class="<?php echo $deadline_groups_col_class; ?>">
+							<div class="col-12">
 							<?php
 								if ( ! is_graduate_degree( $post ) && $undergraduate_deadlines_disclaimer ) {
 									echo $undergraduate_deadlines_disclaimer;


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Forcing a `col-12` on the disclaimer content.

**Motivation and Context**
When there is only one set of application deadlines, the disclaimer content is being put in a side-by-side layout with the deadlines, which isn't what we want. This will force it down below the deadlines.

**How Has This Been Tested?**
Before and after:

![Screenshot 2025-02-10 at 2 26 12 PM](https://github.com/user-attachments/assets/d5d41ed3-b9e8-4c5c-8ca9-f9780ae1f397)


![Screenshot 2025-02-10 at 2 31 06 PM](https://github.com/user-attachments/assets/50f10ecf-c912-43f3-9cf3-c7d07990ef5d)

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
