### PR TITLE
Expertise Fixes

### DIFF
--- a/template-expert-search.php
+++ b/template-expert-search.php
@@ -13,8 +13,10 @@ $query                 = isset( $_GET['query'] ) ? sanitize_text_field( $_GET['q
 $paged                 = get_query_var( 'paged' ) ? absint( get_query_var( 'paged' ) ) : 1;
 $college_filter        = isset( $_GET['college'] ) ? sanitize_text_field( $_GET['college'] ) : null;
 $expertise_filter      = isset( $_GET['expertise'] ) ? sanitize_text_field( $_GET['expertise'] ) : null;
+$tag_filter            = isset( $_GET['tag'] ) ? sanitize_text_field( $_GET['tag'] ) : null;
 $college               = null;
 $expertise             = null;
+$tag_term              = null;
 
 // If the user explicitly filtered by college or department,
 // grab the term object:
@@ -24,6 +26,10 @@ if ( $college_filter ) {
 
 if ( $expertise_filter ) {
 	$expertise = get_term_by( 'slug', $expertise_filter, 'expertise' );
+}
+
+if ( $tag_filter ) {
+	$tag_term = get_term_by( 'slug', $tag_filter, 'post_tag' );
 }
 
 // Set up baseline WP_Query args
@@ -46,7 +52,7 @@ if ( $query ) {
 	$args['s'] = $query;
 }
 
-if ( $college || $expertise ) {
+if ( $college || $expertise || $tag ) {
 	$args['tax_query']['relation'] = 'AND';
 }
 
@@ -65,6 +71,16 @@ if ( $expertise ) {
 		'terms'    => $expertise->term_id
 	);
 }
+
+if ( $tag_term ) {
+	$args['tax_query'][] = array(
+		'taxonomy' => 'post_tag',
+		'field'    => 'term_id',
+		'terms'    => $tag_term->term_id
+	);
+}
+
+var_dump( $query );
 
 // If we're performing a search for a faculty member
 // by person name and Relevanssi is enabled, use
@@ -196,8 +212,8 @@ if ( $query && function_exists( 'relevanssi_do_query' ) ) {
 									<?php
 									foreach ( $person_tags as $person_tag ) :
 										$person_tag_filter_url = add_query_arg(
-											'query',
-											$person_tag->name,
+											'tag',
+											$person_tag->slug,
 											$page_permalink
 										);
 									?>

--- a/template-parts/expert/at_a_glance.php
+++ b/template-parts/expert/at_a_glance.php
@@ -36,7 +36,7 @@ if ( $post->post_type === 'person' ) :
 									<ul class="mb-4">
 									<?php foreach( $expertise as $exp ) : ?>
 										<li class="list-item my-1 mr-2">
-											<a href="<?php echo get_expert_filter_url( $exp->name ); ?>">
+											<a href="<?php echo get_expert_filter_url( $exp->slug ); ?>">
 												<?php echo $exp->name; ?>
 											</a>
 										</li>
@@ -51,8 +51,8 @@ if ( $post->post_type === 'person' ) :
 										<?php
 										foreach ( $tags as $tag ) :
 											$tag_filter_url = add_query_arg(
-												'query',
-												$tag->name,
+												'tag',
+												$tag->slug,
 												$page_permalink
 											);
 										?>


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
* Added logic specifically for filtering by tag (instead of relying on Relevanssi)
* Updated tag URLs to use the new tag specific filtering URL
* Ensures the expertise filter on the expert profile view filter by the expertise slug instead of the expertise name.  

**Motivation and Context**
Changing the expertise URL on the expert profiles will correct the issue where the URLs appear to be different between clicking on the expertise in the search view vs the profile view. Now they point to the same URL and the results will be the same.

Additionally, the reported URL difference between clicking on the expertise in the typeahead results and just clicking the search button is intended and unavoidable. When clicking the search button (or just pressing enter) the user is providing a general query. We have to assume that what they're searching is just a regular query, and search accordingly. I would argue that in most cases this is fine, since the results for `?expertise=something` and `?query=something` are very likely to be nearly identical. Relevanssi searching taxonomy terms when it searches, and gives high priority to records that have a taxonomy term match.

**How Has This Been Tested?**
We'll have to deploy this to DEV after review before we can really play with this to test.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
