### PR TITLE
Added the logic to display the quote on the Degree pages.

### DIFF
--- a/template-parts/degree/quotes.php
+++ b/template-parts/degree/quotes.php
@@ -9,22 +9,17 @@ if ( $post->post_type === 'degree' ) :
 			<div class="container">
 				<?php while ( have_rows( 'degree_quotes', $post ) ) : the_row(); ?>
 					<div class="row">
-						<?php if ( ( get_sub_field( 'degree_quote_image_source' ) === 'upload' )  && ( get_sub_field( 'degree_quote_image' ) ) ) : ?>
+						<?php
+							$source = get_sub_field( 'degree_quote_image_source' );
+							$img_url = $source === 'upload' ? get_sub_field( 'degree_quote_image' ) : get_sub_field( 'degree_quote_image_url' );
+						?>
+						<?php if ( $img_url ) : ?>
 							<div class="col-lg-3 text-center text-lg-right align-self-center">
-								<img src="<?php the_sub_field( 'degree_quote_image' ); ?>" class="img-fluid rounded-circle"
-									alt="<?php the_sub_field( 'degree_quote_image_alt' ); ?>">
-							</div>
-						<?php elseif ( ( get_sub_field( 'degree_quote_image_source') === 'url' ) && ( get_sub_field( 'degree_quote_image_url' ) ) ) : ?>
-							<div class="col-lg-3 text-center text-lg-right align-self-center">
-								<img src="<?php the_sub_field( 'degree_quote_image_url' ); ?>" class="img-fluid rounded-circle"
+								<img src="<?php echo $img_url ?>" class="img-fluid rounded-circle"
 									alt="<?php the_sub_field( 'degree_quote_image_alt' ); ?>">
 							</div>
 						<?php endif; ?>
-						<?php $quote_col_class = (
-							get_sub_field( 'degree_quote_image' ) &&
-							get_sub_field( 'degree_quote_image_source' ) === 'upload' ||
-							get_sub_field( 'degree_quote_image_url' ) &&
-							get_sub_field( 'degree_quote_image_source' ) === 'url' ) ?
+						<?php $quote_col_class = ( $img_url ) ?
 							"col-lg-9" :
 							"col-12 col-xl-10 offset-xl-1";
 						?>

--- a/template-parts/degree/quotes.php
+++ b/template-parts/degree/quotes.php
@@ -9,17 +9,33 @@ if ( $post->post_type === 'degree' ) :
 			<div class="container">
 				<?php while ( have_rows( 'degree_quotes', $post ) ) : the_row(); ?>
 					<div class="row">
-						<?php if( get_sub_field( 'degree_quote_image' ) ) : ?>
+						<?php if ( ( get_sub_field( 'degree_quote_image_source' ) === 'upload' )  && ( get_sub_field( 'degree_quote_image' ) ) ) : ?>
 							<div class="col-lg-3 text-center text-lg-right align-self-center">
-								<img src="<?php the_sub_field( 'degree_quote_image' ); ?>" class="img-fluid"
+								<img src="<?php the_sub_field( 'degree_quote_image' ); ?>" class="img-fluid rounded-circle"
+									alt="<?php the_sub_field( 'degree_quote_image_alt' ); ?>">
+							</div>
+						<?php elseif ( ( get_sub_field( 'degree_quote_image_source') === 'url' ) && ( get_sub_field( 'degree_quote_image_url' ) ) ) : ?>
+							<div class="col-lg-3 text-center text-lg-right align-self-center">
+								<img src="<?php the_sub_field( 'degree_quote_image_url' ); ?>" class="img-fluid rounded-circle"
 									alt="<?php the_sub_field( 'degree_quote_image_alt' ); ?>">
 							</div>
 						<?php endif; ?>
-						<?php $quote_col_class = ( get_sub_field( 'degree_quote_image' ) ) ? "col-lg-9" : "col-12 col-xl-10 offset-xl-1"; ?>
+						<?php $quote_col_class = (
+							get_sub_field( 'degree_quote_image' ) &&
+							get_sub_field( 'degree_quote_image_source' ) === 'upload' ||
+							get_sub_field( 'degree_quote_image_url' ) &&
+							get_sub_field( 'degree_quote_image_source' ) === 'url' ) ?
+							"col-lg-9" :
+							"col-12 col-xl-10 offset-xl-1";
+						?>
 						<div class="<?php echo $quote_col_class; ?>">
 							<blockquote class="blockquote blockquote-quotation">
-								<p class="mb-0"><?php the_sub_field( 'degree_quote' ); ?></p>
-								<footer class="blockquote-footer"><?php the_sub_field( 'degree_quote_footer' ); ?></footer>
+								<p class="mb-0">
+									<?php the_sub_field( 'degree_quote' ); ?>”
+								</p>
+								<footer class="blockquote-footer mt-3">
+									<?php the_sub_field( 'degree_quote_footer' ); ?>
+								</footer>
 							</blockquote>
 						</div>
 					</div>

--- a/template-parts/degree/quotes.php
+++ b/template-parts/degree/quotes.php
@@ -12,17 +12,13 @@ if ( $post->post_type === 'degree' ) :
 						<?php
 							$source = get_sub_field( 'degree_quote_image_source' );
 							$img_url = $source === 'upload' ? get_sub_field( 'degree_quote_image' ) : get_sub_field( 'degree_quote_image_url' );
+							$quote_col_class = ( $img_url ) ? "col-lg-9" : "col-12 col-xl-10 offset-xl-1";
 						?>
 						<?php if ( $img_url ) : ?>
 							<div class="col-lg-3 text-center text-lg-right align-self-center">
-								<img src="<?php echo $img_url ?>" class="img-fluid rounded-circle"
-									alt="<?php the_sub_field( 'degree_quote_image_alt' ); ?>">
+								<img src="<?php echo $img_url ?>" class="img-fluid rounded-circle" alt="<?php the_sub_field( 'degree_quote_image_alt' ); ?>">
 							</div>
 						<?php endif; ?>
-						<?php $quote_col_class = ( $img_url ) ?
-							"col-lg-9" :
-							"col-12 col-xl-10 offset-xl-1";
-						?>
 						<div class="<?php echo $quote_col_class; ?>">
 							<blockquote class="blockquote blockquote-quotation">
 								<p class="mb-0">

--- a/template-parts/degree/quotes.php
+++ b/template-parts/degree/quotes.php
@@ -12,7 +12,7 @@ if ( $post->post_type === 'degree' ) :
 						<?php
 							$source = get_sub_field( 'degree_quote_image_source' );
 							$img_url = $source === 'upload' ? get_sub_field( 'degree_quote_image' ) : get_sub_field( 'degree_quote_image_url' );
-							$quote_col_class = ( $img_url ) ? "col-lg-9" : "col-12 col-xl-10 offset-xl-1";
+							$quote_col_class = $img_url ? "col-lg-9" : "col-12 col-xl-10 offset-xl-1";
 						?>
 						<?php if ( $img_url ) : ?>
 							<div class="col-lg-3 text-center text-lg-right align-self-center">


### PR DESCRIPTION
**Description**
After the monthly importer runs, we pull data from the Dashboard Contributor and overwrite the quote section on the degree page. If an image URL is available, it will be prioritized. However, if a user uploads an image through the WordPress dashboard and select the Image source to Uploaded image, that image will be displayed instead.

<img width="1907" alt="Screenshot 2025-06-26 at 12 05 39 PM" src="https://github.com/user-attachments/assets/216d2265-efb8-4f39-810a-3dcd7a1de155" />

**How Has This Been Tested?**
Tested on local environment.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
