### PR TITLE
Updated college_url_clean to correct syntax error

### DIFF
--- a/includes/degree-functions.php
+++ b/includes/degree-functions.php
@@ -687,7 +687,7 @@ function generate_degree_json_schema( $degree, $post_meta = null ) {
 	$college_profile_url = get_term_link( $college );
 
 	$college_url = get_field( 'colleges_url', 'colleges_' . $college->term_id );
-	$college_url_clean = explode( '?', $college_url )[0] ? $college_url : null;
+	$college_url_clean =  $college_url ? explode( '?', $college_url )[0] : null;
 
 	if ( $college ) {
 		$retval['provider'] = array(


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Corrects a syntax error that removed the query parameters from the `sameAs` property on degree schemas for the college record.

**Motivation and Context**
We want a clean URL without the UTM parameters for this field. This corrects the syntax so that is what gets spit out.

**How Has This Been Tested?**
Changes have been confirmed locally and will be tested again in DEV after this is tagged (that's how we identified the problem).

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
