### PR TITLE
Sharp and brand icons were removed from header

### DIFF
--- a/includes/meta.php
+++ b/includes/meta.php
@@ -162,16 +162,10 @@ if ( $gw_verify ):
 
 <?php // Preload Font Awesome
 $fonts_array = array(
-	'/font-awesome-pro/fa-brands-400.woff2',
-	'/font-awesome-pro/fa-duotone-900.woff2',
+	'/font-awesome-pro/fa-thin-100.woff2',
 	'/font-awesome-pro/fa-light-300.woff2',
 	'/font-awesome-pro/fa-regular-400.woff2',
-	'/font-awesome-pro/fa-sharp-light-300.woff2',
-	'/font-awesome-pro/fa-sharp-regular-400.woff2',
-	'/font-awesome-pro/fa-sharp-solid-900.woff2',
-	'/font-awesome-pro/fa-sharp-thin-100.woff2',
 	'/font-awesome-pro/fa-solid-900.woff2',
-	'/font-awesome-pro/fa-thin-100.woff2',
 	'/font-awesome-pro/fa-v4compatibility.woff2',
 );
 foreach ($fonts_array as $font) {


### PR DESCRIPTION
**Description**
Since we have removed the font awesome sharp and duotone package, we need to remove the addresses from preload in header

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
