### PR TITLE
Colleges grid CTA

### DIFF
--- a/includes/college-functions.php
+++ b/includes/college-functions.php
@@ -86,7 +86,7 @@ function get_colleges_grid( $exclude_term=null ) {
 		?>
 		<?php if ( $activate_cta ) : ?>
 			<a href="<?php echo $cta_link; ?>" class="colleges-block bg-primary text-right text-decoration-none justify-content-end">
-				<p><?php echo apply_filters( 'the_content', $cta_content ); ?></p>
+				<?php echo apply_filters( 'the_content', $cta_content ); ?>
 			</a>
 		<?php endif; ?>
 	</div>

--- a/includes/college-functions.php
+++ b/includes/college-functions.php
@@ -85,7 +85,7 @@ function get_colleges_grid( $exclude_term=null ) {
 		endforeach;
 		?>
 		<?php if ( $activate_cta ) : ?>
-			<a href="<?php echo $cta_link; ?>" class="colleges-block bg-primary text-right text-decoration-none justify-content-end">
+			<a href="<?php echo $cta_link; ?>" class="colleges-block bg-primary text-decoration-none">
 				<?php echo apply_filters( 'the_content', $cta_content ); ?>
 			</a>
 		<?php endif; ?>

--- a/includes/college-functions.php
+++ b/includes/college-functions.php
@@ -57,6 +57,11 @@ function display_custom_top_degrees( $term ) {
  */
 function get_colleges_grid( $exclude_term=null ) {
 	$colleges = get_terms( array( 'taxonomy' => 'colleges', 'hide_empty' => false ) );
+
+	$activate_cta = get_theme_mod_or_default( 'degrees_colleges_activate_cta' );
+	$cta_link     = get_theme_mod_or_default( 'degrees_colleges_cta_link' );
+	$cta_content  = get_theme_mod_or_default( 'degrees_colleges_cta_content' );
+
 	ob_start();
 
 	if ( $colleges ):
@@ -79,6 +84,11 @@ function get_colleges_grid( $exclude_term=null ) {
 			endif;
 		endforeach;
 		?>
+		<?php if ( $activate_cta ) : ?>
+			<a href="<?php echo $cta_link; ?>" class="colleges-block bg-primary text-right text-decoration-none justify-content-end">
+				<p><?php echo apply_filters( 'the_content', $cta_content ); ?></p>
+			</a>
+		<?php endif; ?>
 	</div>
 </section>
 <?php

--- a/includes/config.php
+++ b/includes/config.php
@@ -28,6 +28,7 @@ define( 'THEME_CUSTOMIZER_DEFAULTS', serialize( array(
 										   . 'a wide range of opportunity, like learning diverse skills from world-renowned '
 										   . 'faculty to networking with top employers across Central Florida to gaining '
 										   . 'first-hand experience in internships nearby. Achieve your degree and more as a Knight.',
+	'degrees_colleges_activate_cta'       => false,
 	'gw_verify'                           => '8hYa3fslnyoRE8vg6COo48-GCMdi5Kd-1qFpQTTXSIw',
 	'gtm_id'                              => 'GTM-MBPLZH',
 	'google_map_key'                      => '',
@@ -122,6 +123,14 @@ function define_customizer_sections( $wp_customize ) {
 		THEME_CUSTOMIZER_PREFIX . 'degrees-skills_careers',
 		array(
 			'title' => 'Skills and Career Opportunities',
+			'panel' => THEME_CUSTOMIZER_PREFIX . 'degrees'
+		)
+	);
+
+	$wp_customize->add_section(
+		THEME_CUSTOMIZER_PREFIX . 'degrees-colleges',
+		array(
+			'title' => 'Colleges',
 			'panel' => THEME_CUSTOMIZER_PREFIX . 'degrees'
 		)
 	);
@@ -746,6 +755,52 @@ function define_customizer_fields( $wp_customize ) {
 			'label'       => 'Degree Career Program Limit',
 			'description' => 'The maximum number of job careers to import from the search service.',
 			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-skills_careers'
+		)
+	);
+
+	// Colleges
+	$wp_customize->add_setting(
+		'degrees_colleges_activate_cta',
+		array(
+			'default' => get_theme_mod_default( 'degrees_colleges_activate_cta' )
+		)
+	);
+
+	$wp_customize->add_control(
+		'degrees_colleges_activate_cta',
+		array(
+			'type'        => 'checkbox',
+			'label'       => 'Activate Colleges Grid CTA',
+			'description' => 'Adds a single item to the colleges grid that can be used as a customizable call to action',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-colleges'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_colleges_cta_link'
+	);
+
+	$wp_customize->add_control(
+		'degrees_colleges_cta_link',
+		array(
+			'type'        => 'text',
+			'label'       => 'Colleges grid CTA Link URL',
+			'description' => 'The URL of the call to action grid item in the colleges grid',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-colleges'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'degrees_colleges_cta_content'
+	);
+
+	$wp_customize->add_control(
+		'degrees_colleges_cta_content',
+		array(
+			'type'        => 'textarea',
+			'label'       => 'Colleges grid CTA Content',
+			'description' => 'The content of the colleges grid call to action. Supports HTML.',
+			'section'     => THEME_CUSTOMIZER_PREFIX . 'degrees-colleges'
 		)
 	);
 


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds a simple CTA to the end of the grid of colleges displayed on the college template.

**Motivation and Context**
We now have one less college at UCF, making an empty space that needs to be filled in the grid. This CTA can be turned on and off, so if another college is created, we can just turn the CTA back off.

**How Has This Been Tested?**
Changes have been tested locally. Here is what the customizer controls look like, and the output on the page.

<img width="462" height="445" alt="Screenshot 2025-09-03 at 1 27 43 PM" src="https://github.com/user-attachments/assets/d3c2d1fa-f9c0-4f19-99a5-c2289e7f1098" />

<img width="2088" height="791" alt="Screenshot 2025-09-03 at 1 25 51 PM" src="https://github.com/user-attachments/assets/3374cef8-8c6e-4974-a8d7-8493b04495eb" />


**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
