### PR TITLE
Video Highlight Accessibility

### DIFF
--- a/template-video.php
+++ b/template-video.php
@@ -37,9 +37,9 @@ $additional_content = get_field( 'video_additional_content', $post->ID );
 				<?php foreach( $video_sections as $idx => $section ) : ?>
 					<?php $section_id = sanitize_title( $section['section_title'] ); ?>
 					<div class="card">
-						<div class="card-header" id="<?php echo $section_id; ?>-id" role="tab">
+						<div class="card-header" id="<?php echo $section_id; ?>-id">
 							<h3 class="h5 mb-0">
-								<a class="font-size-base text-secondary" data-toggle="collapse" href="#<?php echo $section_id; ?>"<?php echo ( $idx === 0 ) ? "aria-expanded=\"true\"" : ""; ?> aria-controls="<?php echo $section_id; ?>">
+								<a class="font-size-base text-secondary" data-toggle="collapse" href="#<?php echo $section_id; ?>" role="tab" aria-expanded="<?php echo ( $idx === 0 ) ? 'true' : 'false'; ?>" aria-selected="<?php echo ( $idx === 0 ) ? 'true' : 'false'; ?>" aria-controls="<?php echo $section_id; ?>">
 									<?php echo $section['section_title']; ?>
 								</a>
 							</h3>

--- a/template-video.php
+++ b/template-video.php
@@ -39,7 +39,7 @@ $additional_content = get_field( 'video_additional_content', $post->ID );
 					<div class="card">
 						<div class="card-header" id="<?php echo $section_id; ?>-id">
 							<h3 class="h5 mb-0">
-								<a class="font-size-base text-secondary" data-toggle="collapse" href="#<?php echo $section_id; ?>" role="tab" aria-expanded="<?php echo ( $idx === 0 ) ? 'true' : 'false'; ?>" aria-selected="<?php echo ( $idx === 0 ) ? 'true' : 'false'; ?>" aria-controls="<?php echo $section_id; ?>">
+								<a class="font-size-base text-secondary" data-toggle="collapse" href="#<?php echo $section_id; ?>" role="tab" aria-expanded="<?php echo ( $idx === 0 ) ? 'true' : 'false'; ?>" aria-controls="<?php echo $section_id; ?>">
 									<?php echo $section['section_title']; ?>
 								</a>
 							</h3>

--- a/template-video.php
+++ b/template-video.php
@@ -37,7 +37,7 @@ $additional_content = get_field( 'video_additional_content', $post->ID );
 				<?php foreach( $video_sections as $idx => $section ) : ?>
 					<?php $section_id = sanitize_title( $section['section_title'] ); ?>
 					<div class="card">
-						<div class="card-header" id="<?php echo $section_id; ?>-id">
+						<div class="card-header" id="<?php echo $section_id; ?>-id" role="tab">
 							<h3 class="h5 mb-0">
 								<a class="font-size-base text-secondary" data-toggle="collapse" href="#<?php echo $section_id; ?>"<?php echo ( $idx === 0 ) ? "aria-expanded=\"true\"" : ""; ?> aria-controls="<?php echo $section_id; ?>">
 									<?php echo $section['section_title']; ?>


### PR DESCRIPTION
**Description**
Moved the `tab` role from the non-focusable `<div class="card-header">` to the interactive `<a>` element for each video highlight. Added `aria-expanded` (always present with explicit `true`/`false` values) and `aria-selected` attributes to properly expose tab state to accessibility software.

**Motivation and Context**
The ARIA tabs pattern requires the element with `role="tab"` to be focusable and expose state. Placing `role="tab"` on a non-interactive `<div>` meant screen readers could not properly announce or operate the tabs. Moving the role to the `<a>` element (consistent with the pattern used in `template-parts/degree/course_overview.php`) and adding the required state attributes ensures correct behavior. Also fixes a string concatenation bug where `aria-expanded` was emitted without a leading space when `$idx === 0`, which could produce invalid HTML.

**How Has This Been Tested?**
We'll have to retest with SiteImprove to make sure this is satisfactory.

**Types of changes**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**

- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.