### PR TITLE
Remove fa-sharp class from phonebook search icon

### DIFF
--- a/template-phonebook.php
+++ b/template-phonebook.php
@@ -12,7 +12,7 @@
 
 	<div class="container d-flex">
 		<input class="form-control" type="text" id="gsc-input" placeholder="" />
-		<button class="btn btn-primary d-flex align-items-center" id="gsc-search-button"><span class="fa-sharp fa-solid fa-magnifying-glass mr-2"></span><span>Search</span></button>
+		<button class="btn btn-primary d-flex align-items-center" id="gsc-search-button"><span class="fa-solid fa-magnifying-glass mr-2"></span><span>Search</span></button>
 	</div>
 	<div class="container">
 		<div class="gcse-searchresults-only" data-gname="ucf-phonebook" data-queryParameterName="q"></div>


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
This pull request makes a small UI update to the search button in the `template-phonebook.php` file.

**Motivation and Context**
We dropped support for fa-sharp icons on the theme a while back, so this fixed a broken icon.

- UI update:
  * Changed the search button's icon class from `fa-sharp fa-solid fa-magnifying-glass` to `fa-solid fa-magnifying-glass` for improved icon rendering.

**How Has This Been Tested?**
Tested locally.

<img width="1157" height="158" alt="Screenshot 2026-05-12 at 4 24 08 PM" src="https://github.com/user-attachments/assets/065f5986-f063-4289-bdca-9f20f0fd92d5" />

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
