### PR TITLE
Added code that completely disables the password reset functionality

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -1879,15 +1879,32 @@ add_action( 'manage_person_posts_custom_column' , 'person_admin_set_columns', 10
 add_filter( 'allow_password_reset', '__return_false' );
 
 /**
- * Removes the reset password link from the login page since password reset is disabled
+ * Removes the reset password link text from the login page since password reset is disabled.
+ *
  * @author Jim Barnes
  * @since 3.34.9
- * @param string $text The text to display for the lost password link
- * @return string The modified text to display for the lost password link (empty string to hide
+ *
+ * @param string $translation The translated text.
+ * @param string $text        The original text before translation.
+ * @param string $domain      Text domain.
+ * @return string The modified text to display for the lost password link.
  */
-function mainsite_remove_lostpassword_text ( $text ) {
-    if ($text == 'Lost your password?') {$text = '';}
-    return $text;
+function mainsite_remove_lostpassword_text( $translation, $text, $domain ) {
+	if ( 'Lost your password?' === $text ) {
+		return '';
+	}
+
+	return $translation;
 }
 
-add_filter( 'gettext', 'mainsite_remove_lostpassword_text' );
+/**
+ * Adds the lost password text filter only on login requests.
+ *
+ * @since 3.34.9
+ * @return void
+ */
+function mainsite_setup_login_text_filters() {
+	add_filter( 'gettext', 'mainsite_remove_lostpassword_text', 10, 3 );
+}
+
+add_action( 'login_init', 'mainsite_setup_login_text_filters' );

--- a/includes/config.php
+++ b/includes/config.php
@@ -1873,3 +1873,21 @@ function person_admin_set_columns( $column_name, $post_id ) {
 }
 
 add_action( 'manage_person_posts_custom_column' , 'person_admin_set_columns', 10, 2 );
+
+
+// Completely disable password reset
+add_filter( 'allow_password_reset', '__return_false' );
+
+/**
+ * Removes the reset password link from the login page since password reset is disabled
+ * @author Jim Barnes
+ * @since 3.34.9
+ * @param string $text The text to display for the lost password link
+ * @return string The modified text to display for the lost password link (empty string to hide
+ */
+function mainsite_remove_lostpassword_text ( $text ) {
+    if ($text == 'Lost your password?') {$text = '';}
+    return $text;
+}
+
+add_filter( 'gettext', 'mainsite_remove_lostpassword_text' );


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Disables the password reset functionality on the main site.

**Motivation and Context**
We manage access through SSO, so this function is not needed and only provides an attack vector.

**How Has This Been Tested?**
I can confirm the option is no longer available on my local instance after adding this code.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
