### PR TITLE
Two col template

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -647,6 +647,57 @@
                 "delay": 0
             },
             {
+                "key": "field_6a0a510a23ac5",
+                "label": "Related Degrees Heading",
+                "name": "related_degrees_heading",
+                "aria-label": "",
+                "type": "text",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "Related Degrees",
+                "maxlength": "",
+                "allow_in_bindings": 0,
+                "placeholder": "",
+                "prepend": "",
+                "append": ""
+            },
+            {
+                "key": "field_6a0a510b23ac6",
+                "label": "Related Degrees",
+                "name": "related_degrees",
+                "aria-label": "",
+                "type": "post_object",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "relevanssi_exclude": 0,
+                "post_type": [
+                    "degree"
+                ],
+                "post_status": [
+                    "publish"
+                ],
+                "taxonomy": [],
+                "return_format": "object",
+                "multiple": 1,
+                "allow_null": 1,
+                "allow_in_bindings": 0,
+                "bidirectional": 0,
+                "ui": 1,
+                "bidirectional_target": []
+            },
+            {
                 "key": "field_6a0a510423abf",
                 "label": "Additional Content",
                 "name": "additional_content",

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -601,6 +601,167 @@
         "display_title": ""
     },
     {
+        "key": "group_6a0a510123abc",
+        "title": "Article (Two Column) Fields",
+        "fields": [
+            {
+                "key": "field_6a0a510223abd",
+                "label": "Abstract",
+                "name": "abstract",
+                "aria-label": "",
+                "type": "textarea",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "maxlength": "",
+                "allow_in_bindings": 0,
+                "rows": "",
+                "placeholder": "",
+                "new_lines": ""
+            },
+            {
+                "key": "field_6a0a510323abe",
+                "label": "Sidebar Content",
+                "name": "sidebar_content",
+                "aria-label": "",
+                "type": "wysiwyg",
+                "instructions": "HTML content to display in the right-hand sidebar column. If left empty, the main content column will be centered.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "allow_in_bindings": 0,
+                "tabs": "all",
+                "toolbar": "full",
+                "media_upload": 1,
+                "delay": 0
+            },
+            {
+                "key": "field_6a0a510423abf",
+                "label": "Additional Content",
+                "name": "additional_content",
+                "aria-label": "",
+                "type": "wysiwyg",
+                "instructions": "Full-width content area displayed below the main content and sidebar. Not wrapped in a container.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "allow_in_bindings": 0,
+                "tabs": "all",
+                "toolbar": "full",
+                "media_upload": 1,
+                "delay": 0
+            },
+            {
+                "key": "field_6a0a510523ac0",
+                "label": "FAQs",
+                "name": "faqs",
+                "aria-label": "",
+                "type": "repeater",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "layout": "block",
+                "pagination": 0,
+                "min": 0,
+                "max": 0,
+                "collapsed": "",
+                "button_label": "Add FAQ",
+                "rows_per_page": 20,
+                "sub_fields": [
+                    {
+                        "key": "field_6a0a510623ac1",
+                        "label": "Question",
+                        "name": "question",
+                        "aria-label": "",
+                        "type": "text",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "maxlength": "",
+                        "allow_in_bindings": 0,
+                        "placeholder": "",
+                        "prepend": "",
+                        "append": "",
+                        "parent_repeater": "field_6a0a510523ac0"
+                    },
+                    {
+                        "key": "field_6a0a510723ac2",
+                        "label": "Answer",
+                        "name": "answer",
+                        "aria-label": "",
+                        "type": "wysiwyg",
+                        "instructions": "",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "",
+                        "allow_in_bindings": 0,
+                        "tabs": "all",
+                        "toolbar": "basic",
+                        "media_upload": 0,
+                        "delay": 0,
+                        "parent_repeater": "field_6a0a510523ac0"
+                    }
+                ]
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "page"
+                },
+                {
+                    "param": "post_template",
+                    "operator": "==",
+                    "value": "template-article-two-col.php"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": true,
+        "description": "",
+        "show_in_rest": 0,
+        "display_title": ""
+    },
+    {
         "key": "group_58ff540088983",
         "title": "College Fields",
         "fields": [

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -734,6 +734,48 @@
                         "parent_repeater": "field_6a0a510523ac0"
                     }
                 ]
+            },
+            {
+                "key": "field_6a0a510823ac3",
+                "label": "FAQs Heading",
+                "name": "faqs_heading",
+                "aria-label": "",
+                "type": "text",
+                "instructions": "Heading displayed above the FAQ section. Defaults to \"Frequently Asked Questions\" if left empty.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "maxlength": "",
+                "allow_in_bindings": 0,
+                "placeholder": "Frequently Asked Questions",
+                "prepend": "",
+                "append": ""
+            },
+            {
+                "key": "field_6a0a510923ac4",
+                "label": "Related Stories Heading",
+                "name": "related_stories_heading",
+                "aria-label": "",
+                "type": "text",
+                "instructions": "Heading displayed above the related stories section. Defaults to \"Related Stories\" if left empty.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "maxlength": "",
+                "allow_in_bindings": 0,
+                "placeholder": "Related Stories",
+                "prepend": "",
+                "append": ""
             }
         ],
         "location": [

--- a/template-article-two-col.php
+++ b/template-article-two-col.php
@@ -36,7 +36,9 @@ if ( ! $sidebar_content && ! $related_degrees ) {
 	<div class="row">
 		<div class="<?php echo $main_content_classes; ?>"><!-- Main content column -->
 			<?php echo $thumbnail; ?>
+			<?php if ( ! empty( $abstract ) ) : ?>
 			<div class="abstract mb-4"><p><?php echo $abstract; ?></p></div>
+			<?php endif; ?>
 			<div class="post-content">
 				<?php the_content(); ?>
 			</div>

--- a/template-article-two-col.php
+++ b/template-article-two-col.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Template Name: Article (Two Column)
+ * Template Post Type: page
+ */
+get_header();
+the_post();
+
+$thumbnail = get_the_post_thumbnail(
+	$post->ID,
+	'large',
+	array(
+		'class' => 'article-thumbnail img-fluid mb-4'
+	)
+);
+
+$abstract = get_field( 'abstract', $post->ID );
+$sidebar_content = get_field( 'sidebar_content', $post->ID );
+
+$main_content_classes = 'col-md-8';
+
+if ( ! $sidebar_content ) {
+	$main_content_classes .= ' offset-md-2';
+}
+
+?>
+<article>
+<div class="story-progress sticky-top my-4">
+	<div class="progress bg-faded" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+		<div class="progress-bar bg-primary" style="width: 0%;"></div>
+	</div>
+</div>
+<div class="container mb-4">
+	<div class="row">
+		<div class="<?php echo $main_content_classes; ?>"><!-- Main content column -->
+			<?php echo $thumbnail; ?>
+			<div class="abstract mb-4"><p><?php echo $abstract; ?></p></div>
+			<div class="post-content">
+				<?php the_content(); ?>
+			</div>
+		</div><!-- End main content column -->
+		<?php if ( $sidebar_content ) : ?>
+		<div class="col-md-4"><!-- Sidebar column -->
+			<?php echo $sidebar_content; ?>
+		</div><!-- End sidebar column -->
+		<?php endif; ?>
+	</div>
+</div>
+
+<?php $additional_content = get_field( 'additional_content', $post->ID ); ?>
+<?php if ( $additional_content ) : ?>
+<section class="additional-content">
+	<?php echo $additional_content; ?>
+</section>
+<?php endif; ?>
+
+</article>
+
+<?php
+/**
+ * Related articles
+ */
+$categories = get_the_category( $post->ID );
+$category_ids = wp_list_pluck( $categories, 'term_id' );
+
+$related_args = array(
+	'post_type'      => 'page',
+	'post__not_in'   => array( $post->ID ),
+	'posts_per_page' => 8,
+	'orderby'        => 'rand',
+	'meta_query'     => array(
+		array(
+			'key'     => '_wp_page_template',
+			'value'   => array( 'template-article.php', 'template-article-two-col.php' ),
+			'compare' => 'IN',
+		),
+	),
+);
+
+if ( ! empty( $category_ids ) ) {
+	$related_args['category__in'] = $category_ids;
+}
+
+$related_stories = get_posts( $related_args );
+?>
+
+<?php if ( $related_stories ) : ?>
+<aside class="jumbotron py-5 bg-faded mb-0">
+	<div class="container">
+		<div class="row">
+		<?php foreach ( $related_stories as $story ) :
+			$story_thumbnail = get_the_post_thumbnail( $story->ID, 'post-thumbnail', array(
+				'class' => 'card-img-top img-fluid'
+			) );
+			$story_title = get_field( 'page_header_title', $story->ID );
+			$story_subtitle = get_field( 'page_header_subtitle', $story->ID ) ?? 'Read more...';
+			$permalink = get_permalink( $story->ID );
+		?>
+			<div class="col-6 col-sm-4 col-md-3">
+				<article class="card mb-4">
+					<?php echo $story_thumbnail; ?>
+					<div class="card-block">
+						<a class="text-secondary stretched-link" href="<?php echo esc_url( $permalink ); ?>">
+							<p class="h5 mb-2"><?php echo $story_title; ?></p>
+						</a>
+						<?php if ( ! empty( $story_subtitle ) ) : ?>
+						<p class="text-muted font-size-sm"><?php echo $story_subtitle; ?></p>
+						<?php endif; ?>
+					</div>
+				</article>
+			</div>
+		<?php endforeach; ?>
+		</div>
+	</div>
+</aside>
+<?php endif; ?>
+
+<?php
+/**
+ * FAQs
+ */
+$faqs = get_field( 'faqs', $post->ID );
+?>
+
+<?php if ( $faqs ) : ?>
+<section class="container my-5">
+	<div class="ucf-faq-list ucf-faq-list-classic">
+	<?php foreach ( $faqs as $index => $faq ) :
+		$faq_id = 'page-faq-' . $post->ID . '-' . $index;
+	?>
+	<div class="d-flex mb-4 flex-column">
+		<a href="#<?php echo esc_attr( $faq_id ); ?>" class="ucf-faq-question-link collapsed d-flex" data-toggle="collapse" data-target="#<?php echo esc_attr( $faq_id ); ?>" aria-expanded="false">
+			<div class="ucf-faq-collapse-icon-container mr-2 mr-md-3">
+				<span class="ucf-faq-collapse-icon" aria-hidden="true"></span>
+			</div>
+			<strong class="ucf-faq-question align-self-center mb-0 h5"><?php echo esc_html( $faq['question'] ); ?></strong>
+		</a>
+		<div class="ucf-faq-topic-answer collapse ml-2 ml-md-3 mt-2" id="<?php echo esc_attr( $faq_id ); ?>">
+			<div class="card text-secondary">
+				<div class="card-block">
+					<?php echo $faq['answer']; ?>
+				</div>
+			</div>
+		</div>
+	</div>
+	<?php endforeach; ?>
+	</div>
+</section>
+<?php endif; ?>
+
+<?php get_footer(); ?>

--- a/template-article-two-col.php
+++ b/template-article-two-col.php
@@ -16,10 +16,12 @@ $thumbnail = get_the_post_thumbnail(
 
 $abstract = get_field( 'abstract', $post->ID );
 $sidebar_content = get_field( 'sidebar_content', $post->ID );
+$related_degrees = get_field( 'related_degrees', $post->ID );
+$related_degrees_heading = get_field( 'related_degrees_heading', $post->ID ) ?: 'Related Degrees';
 
 $main_content_classes = 'col-md-8';
 
-if ( ! $sidebar_content ) {
+if ( ! $sidebar_content && ! $related_degrees ) {
 	$main_content_classes .= ' offset-md-2';
 }
 
@@ -39,9 +41,21 @@ if ( ! $sidebar_content ) {
 				<?php the_content(); ?>
 			</div>
 		</div><!-- End main content column -->
-		<?php if ( $sidebar_content ) : ?>
+		<?php if ( $sidebar_content || $related_degrees ) : ?>
 		<div class="col-md-4"><!-- Sidebar column -->
 			<?php echo $sidebar_content; ?>
+			<?php if ( $related_degrees ) : ?>
+			<aside class="card bg-faded mb-4">
+				<div class="card-block">
+					<h2 class="h4 heading-underline"><?php echo esc_html( $related_degrees_heading ); ?></h2>
+					<ul class="list-unstyled">
+					<?php foreach ( $related_degrees as $degree ) : ?>
+						<li><a href="<?php echo esc_url( get_the_permalink( $degree->ID ) ); ?>"><?php echo esc_html( $degree->post_title ); ?></a></li>
+					<?php endforeach; ?>
+					</ul>
+				</div>
+			</aside>
+			<?php endif; ?>
 		</div><!-- End sidebar column -->
 		<?php endif; ?>
 	</div>

--- a/template-article-two-col.php
+++ b/template-article-two-col.php
@@ -89,7 +89,7 @@ if ( $faqs ) {
 
 <?php if ( $faqs ) : ?>
 <section class="container my-5">
-	<h2><?php echo esc_html( $faqs_heading ); ?></h2>
+	<h2 class="mb-4"><?php echo esc_html( $faqs_heading ); ?></h2>
 	<div class="ucf-faq-list ucf-faq-list-classic">
 	<?php foreach ( $faqs as $index => $faq ) :
 		$faq_id = 'page-faq-' . $post->ID . '-' . $index;
@@ -146,7 +146,7 @@ $related_stories_heading = get_field( 'related_stories_heading', $post->ID ) ?: 
 <?php if ( $related_stories ) : ?>
 <aside class="jumbotron py-5 bg-faded mb-0">
 	<div class="container">
-		<h2><?php echo esc_html( $related_stories_heading ); ?></h2>
+		<h2 class="mb-4"><?php echo esc_html( $related_stories_heading ); ?></h2>
 		<div class="row">
 		<?php foreach ( $related_stories as $story ) :
 			$story_thumbnail = get_the_post_thumbnail( $story->ID, 'post-thumbnail', array(

--- a/template-article-two-col.php
+++ b/template-article-two-col.php
@@ -109,7 +109,7 @@ if ( $faqs ) {
 		$faq_id = 'page-faq-' . $post->ID . '-' . $index;
 	?>
 	<div class="d-flex mb-4 flex-column">
-		<a href="#<?php echo esc_attr( $faq_id ); ?>" class="ucf-faq-question-link collapsed d-flex" data-toggle="collapse" data-target="#<?php echo esc_attr( $faq_id ); ?>" aria-expanded="false">
+		<a href="#<?php echo esc_attr( $faq_id ); ?>" class="ucf-faq-question-link collapsed d-flex" data-toggle="collapse" data-target="#<?php echo esc_attr( $faq_id ); ?>" role="button" aria-controls="<?php echo esc_attr( $faq_id ); ?>" aria-expanded="false">
 			<div class="ucf-faq-collapse-icon-container mr-2 mr-md-3">
 				<span class="ucf-faq-collapse-icon" aria-hidden="true"></span>
 			</div>

--- a/template-article-two-col.php
+++ b/template-article-two-col.php
@@ -58,6 +58,64 @@ if ( ! $sidebar_content ) {
 
 <?php
 /**
+ * FAQs
+ */
+$faqs = get_field( 'faqs', $post->ID );
+$faqs_heading = get_field( 'faqs_heading', $post->ID ) ?: 'Frequently Asked Questions';
+
+if ( $faqs ) {
+	add_action( 'wp_footer', function() use ( $faqs ) {
+		$schema = array(
+			'@context'   => 'https://schema.org',
+			'@type'      => 'FAQPage',
+			'mainEntity' => array(),
+		);
+
+		foreach ( $faqs as $faq ) {
+			$schema['mainEntity'][] = array(
+				'@type'          => 'Question',
+				'name'           => wp_strip_all_tags( $faq['question'] ),
+				'acceptedAnswer' => array(
+					'@type' => 'Answer',
+					'text'  => wp_strip_all_tags( $faq['answer'] ),
+				),
+			);
+		}
+
+		echo '<script type="application/ld+json">' . wp_json_encode( $schema, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) . '</script>' . "\n";
+	} );
+}
+?>
+
+<?php if ( $faqs ) : ?>
+<section class="container my-5">
+	<h2><?php echo esc_html( $faqs_heading ); ?></h2>
+	<div class="ucf-faq-list ucf-faq-list-classic">
+	<?php foreach ( $faqs as $index => $faq ) :
+		$faq_id = 'page-faq-' . $post->ID . '-' . $index;
+	?>
+	<div class="d-flex mb-4 flex-column">
+		<a href="#<?php echo esc_attr( $faq_id ); ?>" class="ucf-faq-question-link collapsed d-flex" data-toggle="collapse" data-target="#<?php echo esc_attr( $faq_id ); ?>" aria-expanded="false">
+			<div class="ucf-faq-collapse-icon-container mr-2 mr-md-3">
+				<span class="ucf-faq-collapse-icon" aria-hidden="true"></span>
+			</div>
+			<strong class="ucf-faq-question align-self-center mb-0 h5"><?php echo esc_html( $faq['question'] ); ?></strong>
+		</a>
+		<div class="ucf-faq-topic-answer collapse ml-2 ml-md-3 mt-2" id="<?php echo esc_attr( $faq_id ); ?>">
+			<div class="card text-secondary">
+				<div class="card-block">
+					<?php echo $faq['answer']; ?>
+				</div>
+			</div>
+		</div>
+	</div>
+	<?php endforeach; ?>
+	</div>
+</section>
+<?php endif; ?>
+
+<?php
+/**
  * Related articles
  */
 $categories = get_the_category( $post->ID );
@@ -82,11 +140,13 @@ if ( ! empty( $category_ids ) ) {
 }
 
 $related_stories = get_posts( $related_args );
+$related_stories_heading = get_field( 'related_stories_heading', $post->ID ) ?: 'Related Stories';
 ?>
 
 <?php if ( $related_stories ) : ?>
 <aside class="jumbotron py-5 bg-faded mb-0">
 	<div class="container">
+		<h2><?php echo esc_html( $related_stories_heading ); ?></h2>
 		<div class="row">
 		<?php foreach ( $related_stories as $story ) :
 			$story_thumbnail = get_the_post_thumbnail( $story->ID, 'post-thumbnail', array(
@@ -113,39 +173,6 @@ $related_stories = get_posts( $related_args );
 		</div>
 	</div>
 </aside>
-<?php endif; ?>
-
-<?php
-/**
- * FAQs
- */
-$faqs = get_field( 'faqs', $post->ID );
-?>
-
-<?php if ( $faqs ) : ?>
-<section class="container my-5">
-	<div class="ucf-faq-list ucf-faq-list-classic">
-	<?php foreach ( $faqs as $index => $faq ) :
-		$faq_id = 'page-faq-' . $post->ID . '-' . $index;
-	?>
-	<div class="d-flex mb-4 flex-column">
-		<a href="#<?php echo esc_attr( $faq_id ); ?>" class="ucf-faq-question-link collapsed d-flex" data-toggle="collapse" data-target="#<?php echo esc_attr( $faq_id ); ?>" aria-expanded="false">
-			<div class="ucf-faq-collapse-icon-container mr-2 mr-md-3">
-				<span class="ucf-faq-collapse-icon" aria-hidden="true"></span>
-			</div>
-			<strong class="ucf-faq-question align-self-center mb-0 h5"><?php echo esc_html( $faq['question'] ); ?></strong>
-		</a>
-		<div class="ucf-faq-topic-answer collapse ml-2 ml-md-3 mt-2" id="<?php echo esc_attr( $faq_id ); ?>">
-			<div class="card text-secondary">
-				<div class="card-block">
-					<?php echo $faq['answer']; ?>
-				</div>
-			</div>
-		</div>
-	</div>
-	<?php endforeach; ?>
-	</div>
-</section>
 <?php endif; ?>
 
 <?php get_footer(); ?>


### PR DESCRIPTION
**Description**

> [!NOTE]
> Significant portions of this pull request were AI generated. Including this description.

Adds a new `Article (Two Column)` page template (`template-article-two-col.php`) as a modernized replacement for the existing `template-article.php`. Key features:

- **Two-column layout** — `col-md-8` main content with a `col-md-4` sidebar; main column automatically centers (`offset-md-2`) when no sidebar content is present.
- **Abstract field** — optional textarea displayed above the main page content.
- **Sidebar Content field** — single WYSIWYG field replacing the old repeater-based sidebar, supporting Athena shortcodes and embedded degree list shortcodes.
- **Related Degrees** — post object field (multi-select, `degree` CPT) rendered in the sidebar as a card with a configurable heading and a `list-unstyled` linked list of degree titles.
- **Additional Content** — full-width WYSIWYG section below the main content/sidebar row, not constrained to a container.
- **FAQ section** — ACF repeater (`question` + `answer` subfields) rendered using UCF FAQ plugin markup (`ucf-faq-list-classic`) with Bootstrap collapse toggles and a configurable section heading. Automatically injects `FAQPage` JSON-LD structured data into the page footer when FAQs are present.
- **Related Stories section** — queries pages using both `template-article.php` and `template-article-two-col.php`, filtered by shared categories, displayed as a randomized jumbotron card grid (max 8), with a configurable section heading.

All ACF field definitions for the new `Article (Two Column) Fields` group have been added to `dev/acf-export.json` for import via ACF > Tools > Import.

**Motivation and Context**

The existing `template-article.php` relied on a complex repeater-based sidebar that was difficult to author. This new template simplifies sidebar authoring to a single WYSIWYG field while adding structured features (FAQs with schema markup, related degrees, related stories) that were previously unavailable.

**How Has This Been Tested?**

Tested locally using MAMP. Verified template rendering, sidebar offset logic, FAQ collapse behavior, JSON-LD output, related degrees card, and related stories query. ACF JSON validated programmatically. A dev environment is not available for pre-PR deployment testing.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.