### PR TITLE
Added force degree description field

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -2672,10 +2672,10 @@
                 "relevanssi_exclude": 0,
                 "message": "Force \"View Full Description\" button to display",
                 "default_value": 0,
-                "allow_in_bindings": 1,
-                "ui": 0,
+                "allow_in_bindings": 0,
                 "ui_on_text": "",
-                "ui_off_text": ""
+                "ui_off_text": "",
+                "ui": 1
             },
             {
                 "key": "field_5e99f80012a12",

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -2656,6 +2656,28 @@
                 "ui_off_text": ""
             },
             {
+                "key": "field_6a22de87c8dbf",
+                "label": "Show Catalog Description",
+                "name": "degree_show_catalog_description",
+                "aria-label": "",
+                "type": "true_false",
+                "instructions": "For programs with curated sidebar content (Highlights or other sidebar content), this will force the \"View Full Description\" button to still appear.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "relevanssi_exclude": 0,
+                "message": "Force \"View Full Description\" button to display",
+                "default_value": 0,
+                "allow_in_bindings": 1,
+                "ui": 0,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            },
+            {
                 "key": "field_5e99f80012a12",
                 "label": "Degree Description & Highlights",
                 "name": "",

--- a/template-parts/degree/description/sidebar-curated.php
+++ b/template-parts/degree/description/sidebar-curated.php
@@ -5,6 +5,8 @@ if ( $post->post_type === 'degree' ) :
 	$description_image     = get_field( 'modern_description_image', $post );
 	$description_image_alt = get_field( 'modern_description_image_alt', $post );
 
+	$force_full_desc_btn = get_field( 'degree_show_catalog_description', $post );
+	$catalog_desc_full   = trim( get_field( 'degree_description_full', $post ) );
 
 	if ( $description_image || have_rows( 'highlights', $post ) ) :
 ?>
@@ -46,6 +48,13 @@ if ( $post->post_type === 'degree' ) :
 			?>
 		<?php endif; ?>
 
+		<?php if ( $force_full_desc_btn && $catalog_desc_full ) : ?>
+			<button class="btn btn-outline-info rounded py-3"
+				data-toggle="modal"
+				data-target="#catalogModal">
+				View Full Description
+			</button>
+		<?php endif; ?>
 	</div>
 <?php
 	elseif ( have_rows( 'highlights_imported', $post ) ) : ?>
@@ -77,6 +86,14 @@ if ( $post->post_type === 'degree' ) :
 					endif;
 				endwhile;
 				?>
+			<?php endif; ?>
+
+			<?php if ( $force_full_desc_btn && $catalog_desc_full ) : ?>
+				<button class="btn btn-outline-info rounded py-3"
+					data-toggle="modal"
+					data-target="#catalogModal">
+					View Full Description
+				</button>
 			<?php endif; ?>
 
 		</div>


### PR DESCRIPTION
<!---
Thank you for contributing to the Main Site Theme.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds the "Show Catalog Description" field to non-custom degrees. For instances where the full description button would not be visible (highlights or promos added) this forces the modal button to appear if there is a full description available.

**Motivation and Context**
There are some programs who have provided highlights and other sidebar content who want the full catalog description to still be visible.

**How Has This Been Tested?**
Changes have been verified locally.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
